### PR TITLE
Fix/nextid persistent storage

### DIFF
--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -41,7 +41,15 @@ impl AtomicSwap {
     pub fn initiate_swap(env: Env, ip_id: u64, price: i128, buyer: Address) -> u64 {
         assert!(price > 0, "price must be greater than zero");
         let seller = env.current_contract_address(); // placeholder; real impl uses invoker
-        let id: u64 = env.storage().instance().get(&DataKey::NextId).unwrap_or(0);
+
+        const TTL_THRESHOLD: u32 = 518400;
+        const TTL_BUMP: u32 = 518400;
+
+        let id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NextId)
+            .unwrap_or(0);
 
         let swap = SwapRecord {
             ip_id,
@@ -52,7 +60,10 @@ impl AtomicSwap {
         };
 
         env.storage().persistent().set(&DataKey::Swap(id), &swap);
-        env.storage().instance().set(&DataKey::NextId, &(id + 1));
+        env.storage().persistent().set(&DataKey::NextId, &(id + 1));
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::NextId, TTL_THRESHOLD, TTL_BUMP);
         id
     }
 
@@ -123,6 +134,31 @@ mod tests {
     }
 
     #[test]
+    fn test_next_id_counter_persists_across_calls() {
+        let (env, client) = setup();
+        let buyer = Address::generate(&env);
+        env.mock_all_auths();
+
+        let id0 = client.initiate_swap(&1u64, &100i128, &buyer);
+        let id1 = client.initiate_swap(&2u64, &200i128, &buyer);
+        let id2 = client.initiate_swap(&3u64, &300i128, &buyer);
+
+        assert_eq!(id0, 0);
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
+
+        // counter is in persistent storage — verify directly
+        env.as_contract(&client.address, || {
+            let next: u64 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::NextId)
+                .expect("NextId missing from persistent storage");
+            assert_eq!(next, 3);
+        });
+    }
+
+    #[test]
     fn test_initiate_swap_zero_price_rejected() {
         let (env, client) = setup();
         let buyer = Address::generate(&env);
@@ -140,7 +176,7 @@ mod tests {
 
         // initiate a swap
         let swap_id = env.as_contract(&client.address, || {
-            let id: u64 = env.storage().instance().get(&DataKey::NextId).unwrap_or(0);
+            let id: u64 = env.storage().persistent().get(&DataKey::NextId).unwrap_or(0);
             let swap = SwapRecord {
                 ip_id: 1,
                 seller: seller.clone(),
@@ -149,7 +185,7 @@ mod tests {
                 status: SwapStatus::Pending,
             };
             env.storage().persistent().set(&DataKey::Swap(id), &swap);
-            env.storage().instance().set(&DataKey::NextId, &(id + 1));
+            env.storage().persistent().set(&DataKey::NextId, &(id + 1));
             id
         });
 
@@ -175,7 +211,7 @@ mod tests {
 
         // seed an Accepted swap directly
         let swap_id = env.as_contract(&client.address, || {
-            let id: u64 = env.storage().instance().get(&DataKey::NextId).unwrap_or(0);
+            let id: u64 = env.storage().persistent().get(&DataKey::NextId).unwrap_or(0);
             let swap = SwapRecord {
                 ip_id: 1,
                 seller: seller.clone(),
@@ -184,7 +220,7 @@ mod tests {
                 status: SwapStatus::Accepted,
             };
             env.storage().persistent().set(&DataKey::Swap(id), &swap);
-            env.storage().instance().set(&DataKey::NextId, &(id + 1));
+            env.storage().persistent().set(&DataKey::NextId, &(id + 1));
             id
         });
 

--- a/contracts/ip_registry/src/lib.rs
+++ b/contracts/ip_registry/src/lib.rs
@@ -31,7 +31,14 @@ impl IpRegistry {
     pub fn commit_ip(env: Env, owner: Address, commitment_hash: BytesN<32>) -> u64 {
         owner.require_auth();
 
-        let id: u64 = env.storage().instance().get(&DataKey::NextId).unwrap_or(0);
+        const TTL_THRESHOLD: u32 = 518400;
+        const TTL_BUMP: u32 = 518400;
+
+        let id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NextId)
+            .unwrap_or(0);
 
         let record = IpRecord {
             owner: owner.clone(),
@@ -50,7 +57,10 @@ impl IpRegistry {
         ids.push_back(id);
         env.storage().persistent().set(&DataKey::OwnerIps(owner), &ids);
 
-        env.storage().instance().set(&DataKey::NextId, &(id + 1));
+        env.storage().persistent().set(&DataKey::NextId, &(id + 1));
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::NextId, TTL_THRESHOLD, TTL_BUMP);
         id
     }
 
@@ -78,5 +88,40 @@ impl IpRegistry {
             .persistent()
             .get(&DataKey::OwnerIps(owner))
             .unwrap_or(Vec::new(&env))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    #[test]
+    fn test_next_id_counter_persists_across_calls() {
+        let env = Env::default();
+        let contract_id = env.register(IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let hash = BytesN::from_array(&env, &[0u8; 32]);
+
+        env.mock_all_auths();
+        let id0 = client.commit_ip(&owner, &hash);
+        let id1 = client.commit_ip(&owner, &hash);
+        let id2 = client.commit_ip(&owner, &hash);
+
+        assert_eq!(id0, 0);
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
+
+        // counter is in persistent storage — verify directly
+        env.as_contract(&contract_id, || {
+            let next: u64 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::NextId)
+                .expect("NextId missing from persistent storage");
+            assert_eq!(next, 3);
+        });
     }
 }


### PR DESCRIPTION
closes #12 

Fix: Move NextId to Persistent Storage with TTL Extension

Both ip_registry and atomic_swap contracts were storing the NextId counter in instance storage, which has a shorter TTL than persistent storage. If instance storage expired,
the counter would reset to 0 and new records would silently overwrite existing ones.

Changes:
- Moved NextId reads/writes from instance() to persistent() in both contracts
- Added extend_ttl on every write to keep the counter alive (~30 days per bump)
- Updated test helpers in atomic_swap that were also seeding NextId via instance storage
- Added test_next_id_counter_persists_across_calls to both contracts — verifies IDs increment correctly and the counter lives in persistent storage