### PR TITLE
fix(atomic_swap): return Option from get_swap + add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,100 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+
+jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stable toolchain with rustfmt
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy (wasm32)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stable toolchain with clippy + wasm32 target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+          components: clippy
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-clippy-
+
+      - name: Clippy (wasm32 — contract code)
+        run: >
+          cargo clippy
+          --target wasm32-unknown-unknown
+          --all
+          -- -D warnings
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-test-
+
+      - name: Run tests
+        run: cargo test --all
+
+  build:
+    name: WASM Release Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stable toolchain + wasm32 target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-build-
+
+      - name: Build contracts (wasm32 release)
+        run: cargo build --target wasm32-unknown-unknown --release --all

--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -98,11 +98,45 @@ impl AtomicSwap {
         env.storage().persistent().set(&DataKey::Swap(swap_id), &swap);
     }
 
-    /// Read a swap record.
-    pub fn get_swap(env: Env, swap_id: u64) -> SwapRecord {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Swap(swap_id))
-            .expect("swap not found")
+    /// Read a swap record. Returns None if the swap_id does not exist.
+    pub fn get_swap(env: Env, swap_id: u64) -> Option<SwapRecord> {
+        env.storage().persistent().get(&DataKey::Swap(swap_id))
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::Env;
+
+    #[test]
+    fn get_swap_returns_none_for_nonexistent_id() {
+        let env = Env::default();
+        let contract_id = env.register(AtomicSwap, ());
+        let client = AtomicSwapClient::new(&env, &contract_id);
+
+        // No swaps have been created; any ID should return None
+        let result = client.get_swap(&9999);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn get_swap_returns_some_for_existing_swap() {
+        let env = Env::default();
+        let contract_id = env.register(AtomicSwap, ());
+        let client = AtomicSwapClient::new(&env, &contract_id);
+
+        let buyer = Address::generate(&env);
+        let swap_id = client.initiate_swap(&1_u64, &100_i128, &buyer);
+
+        let result = client.get_swap(&swap_id);
+        assert!(result.is_some());
+        let swap = result.unwrap();
+        assert_eq!(swap.ip_id, 1_u64);
+        assert_eq!(swap.price, 100_i128);
+        assert_eq!(swap.status, SwapStatus::Pending);
     }
 }


### PR DESCRIPTION
close #23 
- Change get_swap return type from SwapRecord to Option<SwapRecord> so callers get None instead of a panic on missing swap IDs
- Add tests: get_swap_returns_none_for_nonexistent_id and get_swap_returns_some_for_existing_swap
- Add .github/workflows/ci.yml with fmt, clippy (wasm32), test, and wasm release build jobs