### PR TITLE
Feature/revoke ip

### DIFF
--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -19,6 +19,7 @@ pub enum ContractError {
     SwapNotInAcceptedState = 11,
     OnlyTheBuyerCanCancelAnExpiredSwap = 12,
     SwapHasNotExpiredYet = 13,
+    IpIsRevoked = 14,
 }
 
 // ── Storage Keys ──────────────────────────────────────────────────────────────
@@ -139,6 +140,11 @@ impl AtomicSwap {
         if record.owner != seller {
             env.panic_with_error(Error::from_contract_error(
                 ContractError::SellerIsNotTheIPOwner as u32,
+            ));
+        }
+        if record.revoked {
+            env.panic_with_error(Error::from_contract_error(
+                ContractError::IpIsRevoked as u32,
             ));
         }
 
@@ -676,10 +682,34 @@ mod tests {
         );
     }
 
+    /// SECURITY: a revoked IP must not be swappable.
+    #[test]
+    fn revoked_ip_cannot_be_swapped() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let (registry_id, ip_id) = setup_registry_with_ip(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 1000);
+
+        // Revoke the IP via the registry
+        let registry = IpRegistryClient::new(&env, &registry_id);
+        registry.revoke_ip(&ip_id);
+
+        let client = AtomicSwapClient::new(&env, &setup_swap(&env));
+        assert!(
+            client
+                .try_initiate_swap(&registry_id, &token_id, &ip_id, &seller, &100_i128, &buyer)
+                .is_err(),
+            "expected initiate_swap to fail for revoked IP"
+        );
+    }
+
     /// SECURITY: a zero price must be rejected to prevent free IP giveaways.
     #[test]
-    fn zero_price_rejected() {
-        let env = Env::default();
+    fn zero_price_rejected() {        let env = Env::default();
         env.mock_all_auths();
 
         let seller = Address::generate(&env);

--- a/contracts/ip_registry/src/lib.rs
+++ b/contracts/ip_registry/src/lib.rs
@@ -13,6 +13,7 @@ pub enum ContractError {
     IpNotFound = 1,
     ZeroCommitmentHash = 2,
     CommitmentAlreadyRegistered = 3,
+    IpAlreadyRevoked = 4,
 }
 
 // ── Storage Keys ────────────────────────────────────────────────────────────
@@ -35,6 +36,7 @@ pub struct IpRecord {
     pub owner: Address,
     pub commitment_hash: BytesN<32>,
     pub timestamp: u64,
+    pub revoked: bool,
 }
 
 // ── Contract ─────────────────────────────────────────────────────────────────
@@ -116,6 +118,7 @@ impl IpRegistry {
             owner: owner.clone(),
             commitment_hash: commitment_hash.clone(),
             timestamp: env.ledger().timestamp(),
+            revoked: false,
         };
 
         env.storage()
@@ -214,6 +217,36 @@ impl IpRegistry {
         );
 
         record.owner = new_owner;
+        env.storage()
+            .persistent()
+            .set(&DataKey::IpRecord(ip_id), &record);
+    }
+
+    /// Revoke an IP record, marking it as invalid.
+    ///
+    /// Only the current owner may revoke. A revoked IP cannot be swapped.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the IP does not exist, the owner does not authorize, or the IP is already revoked.
+    pub fn revoke_ip(env: Env, ip_id: u64) {
+        let mut record: IpRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::IpRecord(ip_id))
+            .unwrap_or_else(|| {
+                env.panic_with_error(Error::from_contract_error(ContractError::IpNotFound as u32))
+            });
+
+        record.owner.require_auth();
+
+        if record.revoked {
+            env.panic_with_error(Error::from_contract_error(
+                ContractError::IpAlreadyRevoked as u32,
+            ));
+        }
+
+        record.revoked = true;
         env.storage()
             .persistent()
             .set(&DataKey::IpRecord(ip_id), &record);

--- a/contracts/ip_registry/src/test.rs
+++ b/contracts/ip_registry/src/test.rs
@@ -12,6 +12,7 @@ mod tests {
         fn get_ip(env: Env, ip_id: u64) -> IpRecord;
         fn list_ip_by_owner(env: Env, owner: Address) -> Option<Vec<u64>>;
         fn transfer_ip(env: Env, ip_id: u64, new_owner: Address);
+        fn revoke_ip(env: Env, ip_id: u64);
     }
 
     #[test]
@@ -212,5 +213,61 @@ mod tests {
             .expect("owner should have committed IPs");
         assert_eq!(owner_ips.len(), 1);
         assert_eq!(owner_ips.get(0).unwrap(), ip_id);
+    }
+
+    #[test]
+    fn test_revoke_ip_marks_record_revoked() {
+        let env = Env::default();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[7u8; 32]);
+
+        env.mock_all_auths();
+        let ip_id = client.commit_ip(&owner, &commitment);
+
+        assert!(!client.get_ip(&ip_id).revoked);
+        client.revoke_ip(&ip_id);
+        assert!(client.get_ip(&ip_id).revoked);
+    }
+
+    #[test]
+    #[should_panic(expected = "ContractError(4)")]
+    fn test_revoke_ip_twice_panics() {
+        let env = Env::default();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        env.mock_all_auths();
+        let ip_id = client.commit_ip(&owner, &BytesN::from_array(&env, &[8u8; 32]));
+        client.revoke_ip(&ip_id);
+        client.revoke_ip(&ip_id); // must panic with IpAlreadyRevoked (code 4)
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_revoke_ip_requires_owner_auth() {
+        let env = Env::default();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let attacker = <Address as TestAddress>::generate(&env);
+        env.mock_all_auths();
+        let ip_id = client.commit_ip(&owner, &BytesN::from_array(&env, &[9u8; 32]));
+
+        // Only mock attacker's auth — owner's auth is absent, must panic
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &attacker,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "revoke_ip",
+                args: (ip_id,).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        client.revoke_ip(&ip_id);
     }
 }


### PR DESCRIPTION
feat(ip_registry): implement revoke_ip

closes #61

Problem

There was no way for an IP owner to invalidate their record if the secret was compromised. A compromised IP could still be listed for sale via 
initiate_swap, exposing buyers to worthless patents.

What changed

ip_registry/src/lib.rs
- Added revoked: bool to IpRecord (set to false in commit_ip)
- Added IpAlreadyRevoked = 4 to ContractError
- Implemented revoke_ip(ip_id): requires current owner auth, panics if already revoked, sets record.revoked = true in persistent storage

contracts/atomic_swap/src/lib.rs
- Added IpIsRevoked = 14 to ContractError
- initiate_swap now rejects any IP where record.revoked == true before creating a swap

ip_registry/src/test.rs
- Exposed revoke_ip in IpRegistryClient trait
- test_revoke_ip_marks_record_revoked — verifies the flag flips from false → true
- test_revoke_ip_twice_panics — confirms ContractError(4) on double-revoke
- test_revoke_ip_requires_owner_auth — confirms non-owner cannot revoke
- revoked_ip_cannot_be_swapped (in atomic_swap tests) — confirms initiate_swap fails for a revoked IP

Auth model

record.owner.require_auth() is called before any mutation. The Soroban host enforces this at the protocol level — no caller can satisfy it for an address 
they don't control.

Testing

bash
cargo test -p ip_registry
cargo test -p atomic_swap