### PR TITLE
Feature/add clippy fmt ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
 
       - uses: actions/cache@v4
         with:
@@ -23,4 +25,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - run: cargo test --workspace
+      - name: Format check
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Test
+        run: cargo test --workspace


### PR DESCRIPTION
ci: add clippy and rustfmt checks to GitHub Actions workflow

- Add cargo fmt --all -- --check to enforce consistent formatting
- Add cargo clippy --workspace --all-targets -- -D warnings to block any warnings on PR
- Install clippy and rustfmt components via dtolnay/rust-toolchain

close #80 