### PR TITLE
Fix/147 148 149 150

### DIFF
--- a/api-server/src/schemas.rs
+++ b/api-server/src/schemas.rs
@@ -57,6 +57,7 @@ pub enum SwapStatus {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct SwapRecord {
     pub ip_id: u64,
+    pub ip_registry_id: String,
     pub seller: String,
     pub buyer: String,
     /// Price in stroops (1 XLM = 10_000_000 stroops)


### PR DESCRIPTION
## Fix API Server Schema Mismatches

Align API schemas with on-chain contract interfaces by adding missing fields and correcting request structures.

### Changes

- **#147**: Add `revoked: bool` field to `IpRecord` schema
- **#148**: Add `token: String` field to `InitiateSwapRequest` schema
- **#149**: Replace `decryption_key` with `secret` and `blinding_factor` fields in `RevealKeyRequest`
- **#150**: Add `ip_registry_id: String` field to `SwapRecord` schema

Closes #147
Closes #148
Closes #149
Closes #150