### PR TITLE
docs: add dispute resolution threat model section (#240)

### DIFF
--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -161,6 +161,79 @@ This document analyzes potential attack vectors in the Atomic Patent swap mechan
 
 **Status**: ✅ Mitigated
 
+## Dispute Resolution Threat Model
+
+### Overview
+
+The dispute resolution feature allows a designated admin (or multi-sig admin group) to adjudicate contested swaps — for example, when a buyer claims the revealed key is invalid despite on-chain verification passing, or when off-chain delivery of associated materials is disputed.
+
+---
+
+### 13. Admin Collusion
+
+**Scenario**: A single admin account is compromised or acts maliciously, ruling in favour of one party to steal funds or IP.
+
+**Impact**: Fraudulent dispute outcomes; loss of buyer funds or seller IP rights.
+
+**Mitigation**:
+- Admin role must be held by a **multi-sig account** (M-of-N threshold, recommended 2-of-3 minimum)
+- All admin actions are recorded on-chain with the admin's address and ledger timestamp
+- A time-lock delay (e.g. 48 hours) between dispute ruling and fund release gives parties time to escalate
+- Governance upgrade path: admin key can be rotated via on-chain vote in future versions
+
+**Operator Recommendation**: Deploy with a multi-sig admin from day one. Never use a single EOA as the dispute admin on mainnet.
+
+**Status**: ⚠️ Partially mitigated (requires operator configuration)
+
+---
+
+### 14. False Dispute Submission
+
+**Scenario**: A buyer or seller raises a dispute in bad faith — e.g. a buyer disputes a valid key reveal to delay payment release, or a seller disputes to stall a refund.
+
+**Impact**: Legitimate counterparty funds locked; griefing / denial-of-service on the swap.
+
+**Mitigation**:
+- Disputes require **on-chain evidence submission** (e.g. a hash of supporting material stored via `dispute_evidence` field)
+- A non-refundable **dispute bond** is required to open a dispute; bond is forfeited if the dispute is ruled frivolous
+- Dispute window is bounded: disputes must be raised within `dispute_period` ledgers after the triggering event
+- Repeated frivolous disputes from the same address can be flagged and rate-limited by the admin
+
+**Operator Recommendation**: Set a meaningful dispute bond (e.g. 10% of swap price, minimum 1 XLM) to deter bad-faith filings. Publish the evidence-submission format in your integration guide.
+
+**Status**: ⚠️ Partially mitigated (requires operator configuration)
+
+---
+
+### 15. Timeout Abuse
+
+**Scenario**: A party deliberately stalls the dispute process — e.g. admin never rules, or a party never submits evidence — to keep funds locked indefinitely or force the other party to abandon their claim.
+
+**Impact**: Funds locked beyond the intended swap expiry; effective denial of refund or payment.
+
+**Mitigation**:
+- **Auto-resolution on timeout**: if the admin has not ruled within `dispute_timeout` ledgers, the contract automatically resolves in favour of the buyer (refund) as the safe default
+- Evidence submission deadline is enforced on-chain; failure to submit evidence within the window is treated as conceding the dispute
+- All timeout thresholds are set at contract initialisation and cannot be changed without a contract upgrade (preventing admin from extending timeouts to stall)
+
+**Operator Recommendation**: Set `dispute_timeout` conservatively (e.g. 14 days / ~120,960 ledgers). Document the auto-resolution default clearly so both parties understand the incentive to act promptly.
+
+**Status**: ✅ Mitigated (when timeout parameters are correctly configured)
+
+---
+
+### Dispute Resolution: Operator Recommendations Summary
+
+| Concern | Recommended Configuration |
+|---|---|
+| Admin collusion | Multi-sig admin, minimum 2-of-3 |
+| False disputes | Require evidence hash on submission; set dispute bond ≥ 1 XLM |
+| Timeout abuse | Set `dispute_timeout` ≤ 14 days; auto-resolve to buyer refund |
+| Audit trail | Log all dispute events (open, evidence, ruling, auto-resolve) on-chain |
+| Key rotation | Plan admin key rotation procedure before mainnet launch |
+
+---
+
 ## Unmitigated Risks
 
 ### Off-Chain Secret Loss


### PR DESCRIPTION
## Summary

Closes #240

Updates `docs/threat-model.md` to cover the dispute resolution feature, which was previously undocumented from a security perspective.

## Changes

Added three new attack scenarios (13–15) under a **Dispute Resolution Threat Model** section:

| # | Attack Vector | Mitigation | Status |
|---|---|---|---|
| 13 | Admin Collusion | Multi-sig admin, on-chain audit trail, time-lock delay | ⚠️ Partially mitigated (operator config) |
| 14 | False Dispute Submission | Evidence hash requirement, dispute bond, bounded dispute window | ⚠️ Partially mitigated (operator config) |
| 15 | Timeout Abuse | Auto-resolution on timeout (defaults to buyer refund), on-chain deadlines | ✅ Mitigated |

Also added an **Operator Recommendations Summary** table consolidating all configuration guidance for dispute resolution.

## No code changes — documentation only.