### PR TITLE
feat(#260): add API request logging and metrics

### DIFF
--- a/TODO_ISSUES.md
+++ b/TODO_ISSUES.md
@@ -1,0 +1,47 @@
+# API Server Issues Implementation TODO
+
+## Execution Order
+1. #260 Logging & Metrics (foundation, no deps)
+2. #259 Rate Limiting (can be independent)
+3. #261 Auth & Authorization (required before webhooks)
+4. #262 Webhook Support (last, leverages auth)
+
+---
+
+## Issue #260 — Logging & Metrics (`blackboxai/issue-260-logging-metrics`)
+- [ ] Create branch
+- [ ] Add dependencies to `api-server/Cargo.toml`
+- [ ] Create `api-server/src/metrics.rs` (Prometheus + structured logging)
+- [ ] Modify `api-server/src/main.rs` (init tracing, /metrics route, TraceLayer)
+- [ ] Modify `api-server/src/handlers.rs` (tracing::instrument)
+- [ ] Commit and push
+
+## Issue #259 — Rate Limiting (`blackboxai/issue-259-rate-limiting`)
+- [ ] Create branch
+- [ ] Add dependencies to `api-server/Cargo.toml`
+- [ ] Create `api-server/src/rate_limit.rs`
+- [ ] Modify `api-server/src/main.rs` (mount RateLimitLayer)
+- [ ] Commit and push
+
+## Issue #261 — Auth & Authorization (`blackboxai/issue-261-auth`)
+- [ ] Create branch
+- [ ] Add dependencies to `api-server/Cargo.toml`
+- [ ] Create `api-server/src/auth.rs`
+- [ ] Modify `api-server/src/main.rs` (auth routes + middleware)
+- [ ] Modify `api-server/src/handlers.rs` (login/refresh)
+- [ ] Modify `api-server/src/schemas.rs` (auth schemas)
+- [ ] Commit and push
+
+## Issue #262 — Webhook Support (`blackboxai/issue-262-webhooks`)
+- [ ] Create branch
+- [ ] Add dependencies to `api-server/Cargo.toml`
+- [ ] Create `api-server/src/webhook.rs`
+- [ ] Modify `api-server/src/main.rs` (webhook routes)
+- [ ] Modify `api-server/src/handlers.rs` (register/unregister + triggers)
+- [ ] Modify `api-server/src/schemas.rs` (webhook schemas)
+- [ ] Commit and push
+
+---
+
+**Status:** In progress
+

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -14,3 +14,11 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 utoipa = { version = "4", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "7", features = ["axum"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+metrics = "0.23"
+metrics-exporter-prometheus = "0.15"
+tower = "0.4"
+tower-http = { version = "0.5", features = ["trace"] }
+http-body-util = "0.1"
+once_cell = "1"

--- a/api-server/src/handlers.rs
+++ b/api-server/src/handlers.rs
@@ -1,4 +1,5 @@
 use axum::{extract::Path, http::StatusCode, Json};
+use tracing::instrument;
 use crate::schemas::*;
 
 /// Timestamp a new IP commitment. Returns the assigned IP ID.
@@ -12,6 +13,7 @@ use crate::schemas::*;
         (status = 400, description = "Invalid request (zero hash, duplicate hash)", body = ErrorResponse),
     )
 )]
+#[instrument(skip(body))]
 pub async fn commit_ip(Json(body): Json<CommitIpRequest>) -> Result<Json<u64>, (StatusCode, Json<ErrorResponse>)> {
     // TODO: Call Soroban RPC to invoke ip_registry.commit_ip
     // For now, return a stub response
@@ -34,6 +36,7 @@ pub async fn commit_ip(Json(body): Json<CommitIpRequest>) -> Result<Json<u64>, (
         (status = 404, description = "IP record not found", body = ErrorResponse),
     )
 )]
+#[instrument]
 pub async fn get_ip(Path(ip_id): Path<u64>) -> Result<Json<IpRecord>, (StatusCode, Json<ErrorResponse>)> {
     // TODO: Call Soroban RPC to invoke ip_registry.get_ip
     // For now, return a stub response
@@ -56,6 +59,7 @@ pub async fn get_ip(Path(ip_id): Path<u64>) -> Result<Json<IpRecord>, (StatusCod
         (status = 404, description = "IP record not found", body = ErrorResponse),
     )
 )]
+#[instrument(skip(body))]
 pub async fn transfer_ip(Json(body): Json<TransferIpRequest>) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     // TODO: Call Soroban RPC to invoke ip_registry.transfer_ip
     Err((
@@ -77,6 +81,7 @@ pub async fn transfer_ip(Json(body): Json<TransferIpRequest>) -> Result<StatusCo
         (status = 404, description = "IP record not found", body = ErrorResponse),
     )
 )]
+#[instrument(skip(body))]
 pub async fn verify_commitment(Json(body): Json<VerifyCommitmentRequest>) -> Result<Json<VerifyCommitmentResponse>, (StatusCode, Json<ErrorResponse>)> {
     // TODO: Call Soroban RPC to invoke ip_registry.verify_commitment
     Err((
@@ -97,6 +102,7 @@ pub async fn verify_commitment(Json(body): Json<VerifyCommitmentRequest>) -> Res
         (status = 200, description = "List of IP IDs (null if none)", body = ListIpByOwnerResponse),
     )
 )]
+#[instrument]
 pub async fn list_ip_by_owner(Path(owner): Path<String>) -> Json<ListIpByOwnerResponse> {
     // TODO: Call Soroban RPC to invoke ip_registry.list_ip_by_owner
     Json(ListIpByOwnerResponse { ip_ids: None })
@@ -113,6 +119,7 @@ pub async fn list_ip_by_owner(Path(owner): Path<String>) -> Json<ListIpByOwnerRe
         (status = 400, description = "Seller is not IP owner or active swap exists", body = ErrorResponse),
     )
 )]
+#[instrument(skip(body))]
 pub async fn initiate_swap(Json(body): Json<InitiateSwapRequest>) -> Result<Json<u64>, (StatusCode, Json<ErrorResponse>)> {
     // TODO: Call Soroban RPC to invoke atomic_swap.initiate_swap
     Err((
@@ -136,6 +143,7 @@ pub async fn initiate_swap(Json(body): Json<InitiateSwapRequest>) -> Result<Json
         (status = 404, description = "Swap not found", body = ErrorResponse),
     )
 )]
+#[instrument(skip(body))]
 pub async fn accept_swap(Path(swap_id): Path<u64>, Json(body): Json<AcceptSwapRequest>) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     // TODO: Call Soroban RPC to invoke atomic_swap.accept_swap
     Err((
@@ -159,6 +167,7 @@ pub async fn accept_swap(Path(swap_id): Path<u64>, Json(body): Json<AcceptSwapRe
         (status = 404, description = "Swap not found", body = ErrorResponse),
     )
 )]
+#[instrument(skip(body))]
 pub async fn reveal_key(Path(swap_id): Path<u64>, Json(body): Json<RevealKeyRequest>) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     // TODO: Call Soroban RPC to invoke atomic_swap.reveal_key
     Err((
@@ -182,6 +191,7 @@ pub async fn reveal_key(Path(swap_id): Path<u64>, Json(body): Json<RevealKeyRequ
         (status = 404, description = "Swap not found", body = ErrorResponse),
     )
 )]
+#[instrument(skip(body))]
 pub async fn cancel_swap(Path(swap_id): Path<u64>, Json(body): Json<CancelSwapRequest>) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     // TODO: Call Soroban RPC to invoke atomic_swap.cancel_swap
     Err((
@@ -205,6 +215,7 @@ pub async fn cancel_swap(Path(swap_id): Path<u64>, Json(body): Json<CancelSwapRe
         (status = 404, description = "Swap not found", body = ErrorResponse),
     )
 )]
+#[instrument(skip(body))]
 pub async fn cancel_expired_swap(Path(swap_id): Path<u64>, Json(body): Json<CancelExpiredSwapRequest>) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     // TODO: Call Soroban RPC to invoke atomic_swap.cancel_expired_swap
     Err((
@@ -226,6 +237,7 @@ pub async fn cancel_expired_swap(Path(swap_id): Path<u64>, Json(body): Json<Canc
         (status = 404, description = "Swap not found", body = ErrorResponse),
     )
 )]
+#[instrument]
 pub async fn get_swap(Path(swap_id): Path<u64>) -> Result<Json<SwapRecord>, (StatusCode, Json<ErrorResponse>)> {
     // TODO: Call Soroban RPC to invoke atomic_swap.get_swap
     Err((

--- a/api-server/src/main.rs
+++ b/api-server/src/main.rs
@@ -1,8 +1,10 @@
 use axum::{routing::get, routing::post, Router};
+use axum::middleware;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
 mod handlers;
+mod metrics;
 mod schemas;
 
 #[derive(OpenApi)]
@@ -50,8 +52,11 @@ pub struct ApiDoc;
 
 #[tokio::main]
 async fn main() {
+    metrics::init();
+
     let app = Router::new()
         .merge(SwaggerUi::new("/docs").url("/openapi.json", ApiDoc::openapi()))
+        .route("/metrics", get(metrics::metrics_handler))
         .route("/ip/commit", post(handlers::commit_ip))
         .route("/ip/{ip_id}", get(handlers::get_ip))
         .route("/ip/transfer", post(handlers::transfer_ip))
@@ -62,10 +67,12 @@ async fn main() {
         .route("/swap/{swap_id}/reveal", post(handlers::reveal_key))
         .route("/swap/{swap_id}/cancel", post(handlers::cancel_swap))
         .route("/swap/{swap_id}/cancel-expired", post(handlers::cancel_expired_swap))
-        .route("/swap/{swap_id}", get(handlers::get_swap));
+        .route("/swap/{swap_id}", get(handlers::get_swap))
+        .layer(middleware::from_fn(metrics::track));
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await.unwrap();
     println!("Swagger UI   -> http://localhost:8080/docs");
     println!("OpenAPI JSON -> http://localhost:8080/openapi.json");
+    println!("Metrics      -> http://localhost:8080/metrics");
     axum::serve(listener, app).await.unwrap();
 }

--- a/api-server/src/metrics.rs
+++ b/api-server/src/metrics.rs
@@ -1,0 +1,119 @@
+use std::time::Instant;
+use axum::{
+    body::Body,
+    extract::Request,
+    http::StatusCode,
+    middleware::Next,
+    response::Response,
+};
+use metrics::{counter, histogram, describe_counter, describe_histogram};
+use tracing::info;
+
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+
+static PROMETHEUS_HANDLE: Lazy<Mutex<metrics_exporter_prometheus::PrometheusHandle>> = Lazy::new(|| {
+    let recorder = metrics_exporter_prometheus::PrometheusBuilder::new()
+        .build_recorder();
+    let handle = recorder.handle();
+    metrics::set_global_recorder(recorder)
+        .expect("Failed to set global metrics recorder");
+    
+    // Describe metrics
+    describe_counter!(
+        "http_requests_total",
+        "Total number of HTTP requests"
+    );
+    describe_histogram!(
+        "http_request_duration_seconds",
+        "HTTP request duration in seconds"
+    );
+    describe_counter!(
+        "http_errors_total",
+        "Total number of HTTP error responses"
+    );
+    
+    Mutex::new(handle)
+});
+
+/// Initialize the Prometheus metrics recorder and JSON logging subscriber.
+pub fn init() {
+    // Ensure the lazy static is initialized
+    let _ = &*PROMETHEUS_HANDLE;
+
+    // Initialize JSON subscriber
+    tracing_subscriber::fmt()
+        .json()
+        .with_env_filter(tracing_subscriber::EnvFilter::new("info"))
+        .with_current_span(false)
+        .with_target(false)
+        .init();
+}
+
+/// Middleware that records structured logs and Prometheus metrics for every request.
+pub async fn track(req: Request, next: Next) -> Response {
+    let start = Instant::now();
+    let method = req.method().to_string();
+    let path = req.uri().path().to_string();
+    let client_ip = extract_client_ip(&req);
+
+    // Execute the request
+    let response = next.run(req).await;
+
+    let latency = start.elapsed();
+    let status = response.status().as_u16();
+
+    // Prometheus metrics
+    counter!(
+        "http_requests_total",
+        "method" => method.clone(),
+        "path" => path.clone(),
+        "status" => status.to_string(),
+    )
+    .increment(1);
+
+    histogram!(
+        "http_request_duration_seconds",
+        "method" => method.clone(),
+        "path" => path.clone(),
+    )
+    .record(latency.as_secs_f64());
+
+    if status >= 400 {
+        counter!(
+            "http_errors_total",
+            "path" => path.clone(),
+            "status" => status.to_string(),
+        )
+        .increment(1);
+    }
+
+    // Structured JSON log
+    info!(
+        method = %method,
+        path = %path,
+        status = status,
+        latency_ms = latency.as_millis() as u64,
+        client_ip = %client_ip,
+        "request completed"
+    );
+
+    response
+}
+
+/// Extract client IP from X-Forwarded-For header or connection info.
+fn extract_client_ip(req: &Request) -> String {
+    req.headers()
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.split(',').next())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Handler for the /metrics endpoint that returns Prometheus exposition format.
+pub async fn metrics_handler() -> Result<String, StatusCode> {
+    let handle = PROMETHEUS_HANDLE.lock().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(handle.render())
+}
+


### PR DESCRIPTION
- Add structured JSON logging via tracing for all requests
- Add Prometheus metrics: http_requests_total, http_request_duration_seconds, http_errors_total
- Add /metrics endpoint for Prometheus exposition format
- Instrument all handlers with #[tracing::instrument]
- Add request tracking middleware with latency, method, path, status, client_ip

closes #260 