### PR TITLE
feat(atomic-swap): implement #251, #252, #253, #254

### DIFF
--- a/contracts/atomic_swap/src/basic_tests.rs
+++ b/contracts/atomic_swap/src/basic_tests.rs
@@ -92,7 +92,7 @@ mod tests {
         let contract_id = setup_swap(&env, &registry_id);
         let client = AtomicSwapClient::new(&env, &contract_id);
 
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
 
         let swap = client.get_swap(&swap_id).expect("swap should exist");
         assert_eq!(swap.seller, seller);
@@ -112,7 +112,7 @@ mod tests {
         let contract_id = setup_swap(&env, &registry_id);
         let client = AtomicSwapClient::new(&env, &contract_id);
 
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
         client.accept_swap(&swap_id);
         client.reveal_key(&swap_id, &seller, &secret, &blinding_factor);
 
@@ -136,7 +136,7 @@ mod tests {
         let client = AtomicSwapClient::new(&env, &contract_id);
         let token_client = TokenClient::new(&env, &token_id);
 
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
 
         client.accept_swap(&swap_id);
         assert_eq!(token_client.balance(&buyer), 0);
@@ -163,7 +163,7 @@ mod tests {
         let client = AtomicSwapClient::new(&env, &contract_id);
         let token_client = TokenClient::new(&env, &token_id);
 
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &300_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &300_i128, &buyer, &0_u32);
         client.accept_swap(&swap_id);
 
         assert_eq!(token_client.balance(&buyer), 700);
@@ -196,7 +196,7 @@ mod tests {
         let client = AtomicSwapClient::new(&env, &contract_id);
 
         // attacker is not the IP owner — must panic
-        client.initiate_swap(&token_id, &ip_id, &attacker, &500_i128, &buyer);
+        client.initiate_swap(&token_id, &ip_id, &attacker, &500_i128, &buyer, &0_u32);
     }
 
     #[test]
@@ -216,7 +216,7 @@ mod tests {
         let contract_id = setup_swap(&env, &registry_id);
         let client = AtomicSwapClient::new(&env, &contract_id);
 
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
         client.accept_swap(&swap_id);
         // attacker != seller — must panic with ContractError(7)
         client.reveal_key(&swap_id, &attacker, &secret, &blinding_factor);
@@ -236,7 +236,7 @@ mod tests {
         let token_id = setup_token(&env, &admin, &buyer, 500);
 
         let client = AtomicSwapClient::new(&env, &setup_swap(&env, &registry_id));
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
         // attacker is neither seller nor buyer — must panic with ContractError(9)
         client.cancel_swap(&swap_id, &attacker);
     }
@@ -256,7 +256,7 @@ mod tests {
         let contract_id = setup_swap(&env, &registry_id);
         let client = AtomicSwapClient::new(&env, &contract_id);
 
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
         client.accept_swap(&swap_id);
 
         let garbage = BytesN::from_array(&env, &[0xffu8; 32]);
@@ -277,7 +277,7 @@ mod tests {
         let contract_id = setup_swap(&env, &registry_id);
         let client = AtomicSwapClient::new(&env, &contract_id);
 
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
         client.accept_swap(&swap_id);
         client.reveal_key(&swap_id, &seller, &secret, &blinding_factor);
 
@@ -303,7 +303,7 @@ mod tests {
         let contract_id = setup_swap(&env, &registry_id);
         let client = AtomicSwapClient::new(&env, &contract_id);
 
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
         client.accept_swap(&swap_id);
         client.reveal_key(&swap_id, &seller, &secret, &blinding_factor);
 
@@ -326,7 +326,7 @@ mod tests {
         let contract_id = setup_swap(&env, &registry_id);
         let client = AtomicSwapClient::new(&env, &contract_id);
 
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
         client.cancel_expired_swap(&swap_id, &buyer);
     }
 
@@ -347,7 +347,7 @@ mod tests {
         let client = AtomicSwapClient::new(&env, &contract_id);
 
         client.initialize(&registry_id);
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
         client.accept_swap(&swap_id);
         client.reveal_key(&swap_id, &seller, &secret, &blinding_factor);
 
@@ -376,7 +376,7 @@ mod tests {
         let contract_id = setup_swap(&env, &registry_id);
         let client = AtomicSwapClient::new(&env, &contract_id);
 
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
         client.cancel_swap(&swap_id, &seller);
 
         let all_events = env.events().all();
@@ -387,5 +387,202 @@ mod tests {
         let observed: SwapCancelledEvent = soroban_sdk::FromVal::from_val(&env, &event.2);
         assert_eq!(observed.swap_id, swap_id);
         assert_eq!(observed.canceller, seller);
+    }
+
+    // ── #251: cancel_pending_swap ─────────────────────────────────────────────
+
+    #[test]
+    fn test_cancel_pending_swap_after_expiry_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let (registry_id, ip_id, _, _) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 500);
+
+        let client = AtomicSwapClient::new(&env, &setup_swap(&env, &registry_id));
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
+
+        // Advance past expiry
+        env.ledger().with_mut(|l| l.timestamp += 604801);
+
+        client.cancel_pending_swap(&swap_id, &buyer);
+        assert_eq!(client.get_swap(&swap_id).unwrap().status, SwapStatus::Cancelled);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #25)")]
+    fn test_cancel_pending_swap_before_expiry_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let (registry_id, ip_id, _, _) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 500);
+
+        let client = AtomicSwapClient::new(&env, &setup_swap(&env, &registry_id));
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
+
+        // Not expired yet — must panic with PendingSwapNotExpired (#25)
+        client.cancel_pending_swap(&swap_id, &buyer);
+    }
+
+    // ── #252: extend_swap_expiry ──────────────────────────────────────────────
+
+    #[test]
+    fn test_extend_swap_expiry_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let (registry_id, ip_id, _, _) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 500);
+
+        let client = AtomicSwapClient::new(&env, &setup_swap(&env, &registry_id));
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
+
+        let old_expiry = client.get_swap(&swap_id).unwrap().expiry;
+        let new_expiry = old_expiry + 86400;
+
+        client.extend_swap_expiry(&swap_id, &new_expiry);
+        assert_eq!(client.get_swap(&swap_id).unwrap().expiry, new_expiry);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #26)")]
+    fn test_extend_swap_expiry_not_greater_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let (registry_id, ip_id, _, _) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 500);
+
+        let client = AtomicSwapClient::new(&env, &setup_swap(&env, &registry_id));
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
+
+        let old_expiry = client.get_swap(&swap_id).unwrap().expiry;
+        // Same expiry — must panic with NewExpiryNotGreater (#26)
+        client.extend_swap_expiry(&swap_id, &old_expiry);
+    }
+
+    // ── #253: swap history ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_swap_history_tracks_state_transitions() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let (registry_id, ip_id, secret, blinding) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 500);
+
+        let client = AtomicSwapClient::new(&env, &setup_swap(&env, &registry_id));
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
+        client.accept_swap(&swap_id);
+        client.reveal_key(&swap_id, &seller, &secret, &blinding);
+
+        let history = client.get_swap_history(&swap_id);
+        assert_eq!(history.len(), 3);
+        assert_eq!(history.get(0).unwrap().status, SwapStatus::Pending);
+        assert_eq!(history.get(1).unwrap().status, SwapStatus::Accepted);
+        assert_eq!(history.get(2).unwrap().status, SwapStatus::Completed);
+    }
+
+    #[test]
+    fn test_swap_history_on_cancellation() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let (registry_id, ip_id, _, _) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 500);
+
+        let client = AtomicSwapClient::new(&env, &setup_swap(&env, &registry_id));
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
+        client.cancel_swap(&swap_id, &seller);
+
+        let history = client.get_swap_history(&swap_id);
+        assert_eq!(history.len(), 2);
+        assert_eq!(history.get(0).unwrap().status, SwapStatus::Pending);
+        assert_eq!(history.get(1).unwrap().status, SwapStatus::Cancelled);
+    }
+
+    // ── #254: multi-sig approval ──────────────────────────────────────────────
+
+    #[test]
+    fn test_approve_swap_and_accept_with_required_approvals() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let approver = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let (registry_id, ip_id, secret, blinding) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 500);
+
+        let client = AtomicSwapClient::new(&env, &setup_swap(&env, &registry_id));
+        // Require 1 approval
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &1_u32);
+
+        client.approve_swap(&swap_id, &approver);
+        client.accept_swap(&swap_id);
+        client.reveal_key(&swap_id, &seller, &secret, &blinding);
+
+        assert_eq!(client.get_swap(&swap_id).unwrap().status, SwapStatus::Completed);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #27)")]
+    fn test_accept_swap_without_required_approvals_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let (registry_id, ip_id, _, _) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 500);
+
+        let client = AtomicSwapClient::new(&env, &setup_swap(&env, &registry_id));
+        // Require 2 approvals but provide none
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &2_u32);
+
+        // Must panic with InsufficientApprovals (#27)
+        client.accept_swap(&swap_id);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #28)")]
+    fn test_duplicate_approval_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let approver = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let (registry_id, ip_id, _, _) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 500);
+
+        let client = AtomicSwapClient::new(&env, &setup_swap(&env, &registry_id));
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &2_u32);
+
+        client.approve_swap(&swap_id, &approver);
+        // Same approver again — must panic with AlreadyApproved (#28)
+        client.approve_swap(&swap_id, &approver);
     }
 }

--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -40,6 +40,14 @@ pub enum ContractError {
     AlreadyInitialized = 22,
     Unauthorized = 23,
     NotInitialized = 24,
+    /// #251: Buyer tried to cancel a pending swap that hasn't expired yet.
+    PendingSwapNotExpired = 25,
+    /// #252: New expiry must be strictly greater than current expiry.
+    NewExpiryNotGreater = 26,
+    /// #254: accept_swap called before all required approvals are collected.
+    InsufficientApprovals = 27,
+    /// #254: Approver has already approved this swap.
+    AlreadyApproved = 28,
 }
 
 // ── TTL ───────────────────────────────────────────────────────────────────────
@@ -68,6 +76,10 @@ pub enum DataKey {
     ProtocolConfig,
     Paused,
     IpSwaps(u64),
+    /// #253: Maps swap_id → Vec<SwapHistoryEntry> audit trail.
+    SwapHistory(u64),
+    /// #254: Maps swap_id → Vec<Address> of collected approvals.
+    SwapApprovals(u64),
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -95,6 +107,8 @@ pub struct SwapRecord {
     /// if reveal_key has not been called. Set at initiation time.
     pub expiry: u64,
     pub accept_timestamp: u64,
+    /// #254: Number of approvals required before accept_swap is allowed.
+    pub required_approvals: u32,
 }
 
 // ── Events ────────────────────────────────────────────────────────────────────
@@ -163,6 +177,35 @@ pub struct ProtocolConfig {
     pub dispute_window_seconds: u64,
 }
 
+// ── #253: Swap History ────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SwapHistoryEntry {
+    pub status: SwapStatus,
+    pub timestamp: u64,
+}
+
+// ── #252: Expiry Extension Event ──────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SwapExpiryExtendedEvent {
+    pub swap_id: u64,
+    pub old_expiry: u64,
+    pub new_expiry: u64,
+}
+
+// ── #254: Swap Approved Event ─────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SwapApprovedEvent {
+    pub swap_id: u64,
+    pub approver: Address,
+    pub approvals_count: u32,
+}
+
 // ── Contract ──────────────────────────────────────────────────────────────────
 
 #[contract]
@@ -191,6 +234,7 @@ impl AtomicSwap {
         seller: Address,
         price: i128,
         buyer: Address,
+        required_approvals: u32,
     ) -> u64 {
         // Guard: reject new swaps when the contract is paused.
         require_not_paused(&env);
@@ -224,6 +268,7 @@ impl AtomicSwap {
             status: SwapStatus::Pending,
             expiry: env.ledger().timestamp() + 604800u64,
             accept_timestamp: 0,
+            required_approvals,
         };
 
         env.storage().persistent().set(&DataKey::Swap(id), &swap);
@@ -254,6 +299,9 @@ impl AtomicSwap {
         env.storage()
             .persistent()
             .extend_ttl(&DataKey::IpSwaps(ip_id), 50000, 50000);
+
+        // #253: Log initial history entry
+        Self::append_history(&env, id, SwapStatus::Pending);
 
         env.storage().instance().set(&DataKey::NextId, &(id + 1));
 
@@ -286,6 +334,20 @@ impl AtomicSwap {
             ContractError::SwapNotPending,
         );
 
+        // #254: Ensure all required approvals have been collected.
+        if swap.required_approvals > 0 {
+            let approvals: Vec<Address> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::SwapApprovals(swap_id))
+                .unwrap_or(Vec::new(&env));
+            if (approvals.len() as u32) < swap.required_approvals {
+                env.panic_with_error(Error::from_contract_error(
+                    ContractError::InsufficientApprovals as u32,
+                ));
+            }
+        }
+
         // Transfer payment from buyer into contract escrow.
         token::Client::new(&env, &swap.token).transfer(
             &swap.buyer,
@@ -297,6 +359,9 @@ impl AtomicSwap {
         swap.status = SwapStatus::Accepted;
 
         swap::save_swap(&env, swap_id, &swap);
+
+        // #253: Log history entry
+        Self::append_history(&env, swap_id, SwapStatus::Accepted);
 
         env.events().publish(
             (soroban_sdk::symbol_short!("swap_acpt"),),
@@ -339,6 +404,9 @@ impl AtomicSwap {
         env.storage()
             .persistent()
             .remove(&DataKey::ActiveSwap(swap.ip_id));
+
+        // #253: Log history entry
+        Self::append_history(&env, swap_id, SwapStatus::Completed);
 
         // Protocol fee deduction
         let token_client = token::Client::new(&env, &swap.token);
@@ -398,6 +466,9 @@ impl AtomicSwap {
             .persistent()
             .remove(&DataKey::ActiveSwap(swap.ip_id));
 
+        // #253: Log history entry
+        Self::append_history(&env, swap_id, SwapStatus::Cancelled);
+
         env.events().publish(
             (soroban_sdk::symbol_short!("swap_cncl"),),
             SwapCancelledEvent { swap_id, canceller },
@@ -429,6 +500,9 @@ impl AtomicSwap {
             &swap.buyer,
             &swap.price,
         );
+
+        // #253: Log history entry
+        Self::append_history(&env, swap_id, SwapStatus::Cancelled);
 
         env.events().publish(
             (soroban_sdk::symbol_short!("s_cancel"),),
@@ -572,6 +646,157 @@ impl AtomicSwap {
     /// Returns the total number of swaps created.
     pub fn swap_count(env: Env) -> u64 {
         env.storage().instance().get(&DataKey::NextId).unwrap_or(0)
+    }
+
+    // ── #251: Buyer cancel pending swap on timeout ────────────────────────────
+
+    /// Buyer cancels a Pending swap after its expiry. No funds are escrowed at
+    /// this stage so no refund transfer is needed.
+    pub fn cancel_pending_swap(env: Env, swap_id: u64, caller: Address) {
+        let mut swap = require_swap_exists(&env, swap_id);
+
+        require_buyer(&env, &caller, &swap);
+        caller.require_auth();
+        require_swap_status(
+            &env,
+            &swap,
+            SwapStatus::Pending,
+            ContractError::SwapNotPending,
+        );
+
+        if env.ledger().timestamp() < swap.expiry {
+            env.panic_with_error(Error::from_contract_error(
+                ContractError::PendingSwapNotExpired as u32,
+            ));
+        }
+
+        swap.status = SwapStatus::Cancelled;
+        swap::save_swap(&env, swap_id, &swap);
+        env.storage()
+            .persistent()
+            .remove(&DataKey::ActiveSwap(swap.ip_id));
+
+        Self::append_history(&env, swap_id, SwapStatus::Cancelled);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("s_cancel"),),
+            SwapCancelledEvent {
+                swap_id,
+                canceller: caller,
+            },
+        );
+    }
+
+    // ── #252: Seller extend swap expiry ──────────────────────────────────────
+
+    /// Seller extends the expiry of a Pending swap to a later timestamp.
+    pub fn extend_swap_expiry(env: Env, swap_id: u64, new_expiry: u64) {
+        let mut swap = require_swap_exists(&env, swap_id);
+
+        swap.seller.require_auth();
+        require_swap_status(
+            &env,
+            &swap,
+            SwapStatus::Pending,
+            ContractError::SwapNotPending,
+        );
+
+        if new_expiry <= swap.expiry {
+            env.panic_with_error(Error::from_contract_error(
+                ContractError::NewExpiryNotGreater as u32,
+            ));
+        }
+
+        let old_expiry = swap.expiry;
+        swap.expiry = new_expiry;
+        swap::save_swap(&env, swap_id, &swap);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("exp_ext"),),
+            SwapExpiryExtendedEvent {
+                swap_id,
+                old_expiry,
+                new_expiry,
+            },
+        );
+    }
+
+    // ── #253: Swap history / audit trail ─────────────────────────────────────
+
+    /// Returns the full state-transition history for a swap.
+    pub fn get_swap_history(env: Env, swap_id: u64) -> Vec<SwapHistoryEntry> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::SwapHistory(swap_id))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    fn append_history(env: &Env, swap_id: u64, status: SwapStatus) {
+        let mut history: Vec<SwapHistoryEntry> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SwapHistory(swap_id))
+            .unwrap_or(Vec::new(env));
+        history.push_back(SwapHistoryEntry {
+            status,
+            timestamp: env.ledger().timestamp(),
+        });
+        env.storage()
+            .persistent()
+            .set(&DataKey::SwapHistory(swap_id), &history);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::SwapHistory(swap_id), LEDGER_BUMP, LEDGER_BUMP);
+    }
+
+    // ── #254: Multi-sig approval ──────────────────────────────────────────────
+
+    /// Any authorized approver submits their approval for a Pending swap.
+    pub fn approve_swap(env: Env, swap_id: u64, approver: Address) {
+        approver.require_auth();
+
+        let swap = require_swap_exists(&env, swap_id);
+        require_swap_status(
+            &env,
+            &swap,
+            SwapStatus::Pending,
+            ContractError::SwapNotPending,
+        );
+
+        let mut approvals: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SwapApprovals(swap_id))
+            .unwrap_or(Vec::new(&env));
+
+        // Prevent duplicate approvals
+        for i in 0..approvals.len() {
+            if approvals.get(i).unwrap() == approver {
+                env.panic_with_error(Error::from_contract_error(
+                    ContractError::AlreadyApproved as u32,
+                ));
+            }
+        }
+
+        approvals.push_back(approver.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::SwapApprovals(swap_id), &approvals);
+        env.storage().persistent().extend_ttl(
+            &DataKey::SwapApprovals(swap_id),
+            LEDGER_BUMP,
+            LEDGER_BUMP,
+        );
+
+        let approvals_count = approvals.len() as u32;
+        env.events().publish(
+            (soroban_sdk::symbol_short!("approved"),),
+            SwapApprovedEvent {
+                swap_id,
+                approver,
+                approvals_count,
+            },
+        );
     }
 }
 

--- a/contracts/atomic_swap/src/tests.rs
+++ b/contracts/atomic_swap/src/tests.rs
@@ -54,7 +54,7 @@ mod tests {
         let contract_id = setup_swap(&env, &registry_id);
         let client = AtomicSwapClient::new(&env, &contract_id);
 
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
 
         let ttl = env.storage().persistent().get_ttl(&DataKey::Swap(swap_id));
         assert!(ttl > 0, "TTL should be set after swap initiation");
@@ -78,7 +78,7 @@ mod tests {
         let contract_id = setup_swap(&env, &registry_id);
         let client = AtomicSwapClient::new(&env, &contract_id);
 
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
         client.accept_swap(&swap_id);
 
         let ttl = env.storage().persistent().get_ttl(&DataKey::Swap(swap_id));
@@ -103,7 +103,7 @@ mod tests {
         let contract_id = setup_swap(&env, &registry_id);
         let client = AtomicSwapClient::new(&env, &contract_id);
 
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
         client.accept_swap(&swap_id);
         client.reveal_key(&swap_id, &seller, &secret, &blinding);
 
@@ -129,7 +129,7 @@ mod tests {
         let contract_id = setup_swap(&env, &registry_id);
         let client = AtomicSwapClient::new(&env, &contract_id);
 
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
         client.cancel_swap(&swap_id, &seller);
 
         let ttl = env.storage().persistent().get_ttl(&DataKey::Swap(swap_id));
@@ -154,7 +154,7 @@ mod tests {
         let contract_id = setup_swap(&env, &registry_id);
         let client = AtomicSwapClient::new(&env, &contract_id);
 
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
         let ttl_init = env.storage().persistent().get_ttl(&DataKey::Swap(swap_id));
 
         client.accept_swap(&swap_id);

--- a/contracts/atomic_swap/src/tests_simple.rs
+++ b/contracts/atomic_swap/src/tests_simple.rs
@@ -53,7 +53,7 @@ mod tests {
         let contract_id = setup_swap(&env, &registry_id);
         let client = AtomicSwapClient::new(&env, &contract_id);
 
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &1000_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &1000_i128, &buyer, &0_u32);
         assert_eq!(client.get_swap(&swap_id).unwrap().status, SwapStatus::Pending);
 
         client.accept_swap(&swap_id);
@@ -77,7 +77,7 @@ mod tests {
         let contract_id = setup_swap(&env, &registry_id);
         let client = AtomicSwapClient::new(&env, &contract_id);
 
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
         client.cancel_swap(&swap_id, &seller);
 
         assert_eq!(client.get_swap(&swap_id).unwrap().status, SwapStatus::Cancelled);
@@ -102,8 +102,8 @@ mod tests {
         let contract_id = setup_swap(&env, &registry_id);
         let client = AtomicSwapClient::new(&env, &contract_id);
 
-        let swap_id_0 = client.initiate_swap(&token_id, &ip_id_0, &seller, &1000_i128, &buyer);
-        let swap_id_1 = client.initiate_swap(&token_id, &ip_id_1, &seller, &1000_i128, &buyer);
+        let swap_id_0 = client.initiate_swap(&token_id, &ip_id_0, &seller, &1000_i128, &buyer, &0_u32);
+        let swap_id_1 = client.initiate_swap(&token_id, &ip_id_1, &seller, &1000_i128, &buyer, &0_u32);
 
         assert_eq!(client.get_swap(&swap_id_0).unwrap().ip_id, ip_id_0);
         assert_eq!(client.get_swap(&swap_id_1).unwrap().ip_id, ip_id_1);
@@ -124,7 +124,7 @@ mod tests {
         let contract_id = setup_swap(&env, &registry_id);
         let client = AtomicSwapClient::new(&env, &contract_id);
 
-        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
 
         assert_eq!(client.get_swap(&swap_id).unwrap().status, SwapStatus::Pending);
     }

--- a/contracts/atomic_swap/src/types.rs
+++ b/contracts/atomic_swap/src/types.rs
@@ -28,6 +28,10 @@ pub enum DataKey {
     IpSwaps(u64),
     /// Whether the contract is paused (blocks initiate_swap and accept_swap).
     Paused,
+    /// #253: Maps swap_id → Vec<SwapHistoryEntry> audit trail.
+    SwapHistory(u64),
+    /// #254: Maps swap_id → Vec<Address> of collected approvals.
+    SwapApprovals(u64),
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -55,6 +59,8 @@ pub struct SwapRecord {
     /// if reveal_key has not been called. Set at initiation time.
     pub expiry: u64,
     pub accept_timestamp: u64,
+    /// #254: Number of approvals required before accept_swap is allowed.
+    pub required_approvals: u32,
 }
 
 // ── Events ────────────────────────────────────────────────────────────────────
@@ -121,4 +127,34 @@ pub struct ProtocolConfig {
     pub protocol_fee_bps: u32,  // 0-10000 (0.00% - 100.00%)
     pub treasury: Address,
     pub dispute_window_seconds: u64,
+}
+
+// ── #253: Swap History ────────────────────────────────────────────────────────
+
+/// A single state-transition entry in the swap audit trail.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SwapHistoryEntry {
+    pub status: SwapStatus,
+    pub timestamp: u64,
+}
+
+// ── #252: Expiry Extension Event ──────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SwapExpiryExtendedEvent {
+    pub swap_id: u64,
+    pub old_expiry: u64,
+    pub new_expiry: u64,
+}
+
+// ── #254: Swap Approved Event ─────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SwapApprovedEvent {
+    pub swap_id: u64,
+    pub approver: Address,
+    pub approvals_count: u32,
 }


### PR DESCRIPTION
## Summary

This PR implements four atomic-swap enhancements in a single commit.

---

### 251 — Buyer cancel pending swap on timeout
- Added `cancel_pending_swap(env, swap_id, caller)` — buyer-only
- Requires `status == Pending` and `now >= swap.expiry` (7-day window)
- Panics with `PendingSwapNotExpired` (#25) if called before expiry
- Emits `SwapCancelledEvent` and logs history entry
- Tests: timeout cancellation succeeds; rejection before expiry

### 252 — Seller extend swap expiry
- Added `extend_swap_expiry(env, swap_id, new_expiry)` — seller-only
- Requires `new_expiry > current_expiry`
- Panics with `NewExpiryNotGreater` (#26) otherwise
- Emits `SwapExpiryExtendedEvent` with `old_expiry` / `new_expiry`
- Tests: extension succeeds; equal/lower expiry rejected

### 253 — Swap history and audit trail
- Added `DataKey::SwapHistory(u64)` → `Vec<SwapHistoryEntry>` (status + timestamp)
- Private `append_history` called on every status transition (Pending, Accepted, Completed, Cancelled)
- Added `get_swap_history(env, swap_id) -> Vec<SwapHistoryEntry>` public query
- Tests: full lifecycle history; cancellation history

### 254 — Multi-signature approval for high-value swaps
- Added `required_approvals: u32` to `SwapRecord` and `initiate_swap`
- Added `DataKey::SwapApprovals(u64)` to track approver addresses
- Added `approve_swap(env, swap_id, approver)` — deduplicates via `AlreadyApproved` (#28)
- `accept_swap` checks `approvals.len() >= required_approvals`, panics `InsufficientApprovals` (#27) if not met
- Tests: multi-sig happy path; accept without approvals rejected; duplicate approval rejected

---

## Files changed
- `contracts/atomic_swap/src/lib.rs` — new functions, updated `initiate_swap` / `accept_swap`, new error codes
- `contracts/atomic_swap/src/types.rs` — new `DataKey` variants, `SwapRecord` field, event structs, `SwapHistoryEntry`
- `contracts/atomic_swap/src/basic_tests.rs` — 9 new tests + updated call sites
- `contracts/atomic_swap/src/tests.rs` — updated `initiate_swap` call sites
- `contracts/atomic_swap/src/tests_simple.rs` — updated `initiate_swap` call sites

Closes #251
Closes #252
Closes #253
Closes #254