### PR TITLE
feat: resolve issues #255, #256, #257, #258 — swap events, dispute timeout, cancel reasons, OpenAPI validation

### DIFF
--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -14,3 +14,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 utoipa = { version = "4", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "7", features = ["axum"] }
+
+[dev-dependencies]
+tower = "0.4"

--- a/api-server/src/main.rs
+++ b/api-server/src/main.rs
@@ -1,4 +1,12 @@
-use axum::{routing::get, routing::post, Router};
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    middleware::{self, Next},
+    response::Response,
+    routing::get,
+    routing::post,
+    Router,
+};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -48,6 +56,23 @@ mod schemas;
 )]
 pub struct ApiDoc;
 
+/// Middleware: reject POST/PUT/PATCH requests whose body is non-empty but lacks
+/// `Content-Type: application/json`.
+async fn require_json_content_type(req: Request<Body>, next: Next) -> Result<Response, StatusCode> {
+    let method = req.method().clone();
+    if matches!(method, axum::http::Method::POST | axum::http::Method::PUT | axum::http::Method::PATCH) {
+        let content_type = req
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        if !content_type.starts_with("application/json") {
+            return Err(StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        }
+    }
+    Ok(next.run(req).await)
+}
+
 #[tokio::main]
 async fn main() {
     let app = Router::new()
@@ -62,10 +87,127 @@ async fn main() {
         .route("/swap/{swap_id}/reveal", post(handlers::reveal_key))
         .route("/swap/{swap_id}/cancel", post(handlers::cancel_swap))
         .route("/swap/{swap_id}/cancel-expired", post(handlers::cancel_expired_swap))
-        .route("/swap/{swap_id}", get(handlers::get_swap));
+        .route("/swap/{swap_id}", get(handlers::get_swap))
+        .layer(middleware::from_fn(require_json_content_type));
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await.unwrap();
     println!("Swagger UI   -> http://localhost:8080/docs");
     println!("OpenAPI JSON -> http://localhost:8080/openapi.json");
     axum::serve(listener, app).await.unwrap();
+}
+
+fn build_app() -> Router {
+    Router::new()
+        .route("/ip/commit", post(handlers::commit_ip))
+        .route("/ip/{ip_id}", get(handlers::get_ip))
+        .route("/ip/transfer", post(handlers::transfer_ip))
+        .route("/ip/verify", post(handlers::verify_commitment))
+        .route("/ip/owner/{owner}", get(handlers::list_ip_by_owner))
+        .route("/swap/initiate", post(handlers::initiate_swap))
+        .route("/swap/{swap_id}/accept", post(handlers::accept_swap))
+        .route("/swap/{swap_id}/reveal", post(handlers::reveal_key))
+        .route("/swap/{swap_id}/cancel", post(handlers::cancel_swap))
+        .route("/swap/{swap_id}/cancel-expired", post(handlers::cancel_expired_swap))
+        .route("/swap/{swap_id}", get(handlers::get_swap))
+        .layer(middleware::from_fn(require_json_content_type))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_post_without_content_type_returns_415() {
+        let app = build_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/ip/commit")
+                    .body(Body::from(r#"{"owner":"G123","commitment_hash":"abc"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn test_post_with_wrong_content_type_returns_415() {
+        let app = build_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/ip/commit")
+                    .header("content-type", "text/plain")
+                    .body(Body::from(r#"{"owner":"G123","commitment_hash":"abc"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn test_post_with_json_content_type_passes_middleware() {
+        let app = build_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/ip/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"owner":"G123","commitment_hash":"abc"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // Middleware passes; handler returns 400 (stub), not 415
+        assert_ne!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn test_get_request_bypasses_content_type_check() {
+        let app = build_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/ip/1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_ne!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn test_openapi_json_endpoint_returns_valid_spec() {
+        let app = Router::new()
+            .merge(SwaggerUi::new("/docs").url("/openapi.json", ApiDoc::openapi()))
+            .layer(middleware::from_fn(require_json_content_type));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/openapi.json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let spec: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(spec["info"]["title"], "Atomic Patent API");
+        assert!(spec["paths"].is_object());
+        assert!(spec["components"]["schemas"].is_object());
+    }
 }

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,29 @@
+# Atomic Patent TypeScript Client
+
+Auto-generated TypeScript client from `docs/openapi.yaml`.
+
+## Setup
+
+```bash
+npm install
+```
+
+## Generate type definitions (lightweight, no Java)
+
+```bash
+npm run generate
+```
+
+Outputs `src/client/schema.d.ts` — TypeScript types for all request/response schemas.
+
+## Generate full SDK (requires Java)
+
+```bash
+npm run generate:sdk
+```
+
+Outputs a full `typescript-fetch` SDK to `src/client/sdk/`.
+
+## Re-generate after API changes
+
+Whenever `docs/openapi.yaml` changes, re-run `npm run generate` to keep the client in sync.

--- a/client/openapitools.json
+++ b/client/openapitools.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "7.4.0"
+  }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "atomic-patent-client",
+  "version": "1.0.0",
+  "description": "TypeScript client for the Atomic Patent API, generated from docs/openapi.yaml",
+  "scripts": {
+    "generate": "openapi-typescript ../docs/openapi.yaml -o src/client/schema.d.ts",
+    "generate:sdk": "openapi-generator-cli generate -i ../docs/openapi.yaml -g typescript-fetch -o src/client/sdk --additional-properties=typescriptThreePlus=true"
+  },
+  "devDependencies": {
+    "openapi-typescript": "^6.7.0",
+    "@openapitools/openapi-generator-cli": "^2.13.0"
+  }
+}

--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -4,7 +4,7 @@ mod swap;
 mod utils;
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, token, Address, BytesN, Env, Error, Vec,
+    contract, contracterror, contractimpl, contracttype, token, Address, Bytes, BytesN, Env, Error, Vec,
 };
 
 mod validation;
@@ -69,6 +69,8 @@ pub enum DataKey {
     ProtocolConfig,
     Paused,
     IpSwaps(u64),
+    /// Maps swap_id → cancellation reason bytes. Set only when a swap is cancelled.
+    CancelReason(u64),
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -423,6 +425,10 @@ impl AtomicSwap {
             swap::save_swap(&env, swap_id, &swap);
             env.storage().persistent().remove(&DataKey::ActiveSwap(swap.ip_id));
             token_client.transfer(&env.current_contract_address(), &swap.buyer, &swap.price);
+            env.storage().persistent().set(
+                &DataKey::CancelReason(swap_id),
+                &Bytes::from_slice(&env, b"dispute_refund"),
+            );
         } else {
             swap.status = SwapStatus::Completed;
             swap::save_swap(&env, swap_id, &swap);
@@ -469,6 +475,11 @@ impl AtomicSwap {
             &swap.price,
         );
 
+        env.storage().persistent().set(
+            &DataKey::CancelReason(swap_id),
+            &Bytes::from_slice(&env, b"dispute_timeout"),
+        );
+
         env.events().publish(
             (soroban_sdk::symbol_short!("disp_res"),),
             DisputeResolvedEvent { swap_id, refunded: true },
@@ -494,6 +505,11 @@ impl AtomicSwap {
         env.storage()
             .persistent()
             .remove(&DataKey::ActiveSwap(swap.ip_id));
+
+        env.storage().persistent().set(
+            &DataKey::CancelReason(swap_id),
+            &Bytes::from_slice(&env, b"manual_cancel"),
+        );
 
         env.events().publish(
             (soroban_sdk::symbol_short!("swap_cncl"),),
@@ -525,6 +541,11 @@ impl AtomicSwap {
             &env.current_contract_address(),
             &swap.buyer,
             &swap.price,
+        );
+
+        env.storage().persistent().set(
+            &DataKey::CancelReason(swap_id),
+            &Bytes::from_slice(&env, b"expired"),
         );
 
         env.events().publish(
@@ -667,6 +688,11 @@ impl AtomicSwap {
     /// Read a swap record. Returns `None` if the swap_id does not exist.
     pub fn get_swap(env: Env, swap_id: u64) -> Option<SwapRecord> {
         env.storage().persistent().get(&DataKey::Swap(swap_id))
+    }
+
+    /// Returns the cancellation reason for a swap, or `None` if not cancelled / reason not set.
+    pub fn get_cancellation_reason(env: Env, swap_id: u64) -> Option<Bytes> {
+        env.storage().persistent().get(&DataKey::CancelReason(swap_id))
     }
 
     /// Returns the total number of swaps created.

--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -131,6 +131,8 @@ pub struct SwapCancelledEvent {
 #[derive(Clone, Debug, PartialEq)]
 pub struct KeyRevealedEvent {
     pub swap_id: u64,
+    pub seller_amount: i128,
+    pub fee_amount: i128,
 }
 
 /// Payload published when protocol fee is deducted on swap completion.
@@ -374,7 +376,7 @@ impl AtomicSwap {
 
         env.events().publish(
             (soroban_sdk::symbol_short!("key_rev"),),
-            KeyRevealedEvent { swap_id },
+            KeyRevealedEvent { swap_id, seller_amount, fee_amount },
         );
     }
 

--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -40,6 +40,7 @@ pub enum ContractError {
     AlreadyInitialized = 22,
     Unauthorized = 23,
     NotInitialized = 24,
+    DisputeResolutionTimeout = 25,
 }
 
 // ── TTL ───────────────────────────────────────────────────────────────────────
@@ -95,6 +96,8 @@ pub struct SwapRecord {
     /// if reveal_key has not been called. Set at initiation time.
     pub expiry: u64,
     pub accept_timestamp: u64,
+    /// Ledger timestamp when the dispute was raised. 0 if not disputed.
+    pub dispute_timestamp: u64,
 }
 
 // ── Events ────────────────────────────────────────────────────────────────────
@@ -163,6 +166,7 @@ pub struct ProtocolConfig {
     pub protocol_fee_bps: u32, // 0-10000 (0.00% - 100.00%)
     pub treasury: Address,
     pub dispute_window_seconds: u64,
+    pub dispute_resolution_timeout_seconds: u64,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -226,6 +230,7 @@ impl AtomicSwap {
             status: SwapStatus::Pending,
             expiry: env.ledger().timestamp() + 604800u64,
             accept_timestamp: 0,
+            dispute_timestamp: 0,
         };
 
         env.storage().persistent().set(&DataKey::Swap(id), &swap);
@@ -380,6 +385,96 @@ impl AtomicSwap {
         );
     }
 
+    /// Buyer raises a dispute on an Accepted swap within the dispute window.
+    pub fn raise_dispute(env: Env, swap_id: u64) {
+        let mut swap = require_swap_exists(&env, swap_id);
+        swap.buyer.require_auth();
+        require_swap_status(&env, &swap, SwapStatus::Accepted, ContractError::SwapNotAccepted);
+
+        let config = Self::protocol_config(&env);
+        let elapsed = env.ledger().timestamp().saturating_sub(swap.accept_timestamp);
+        if elapsed >= config.dispute_window_seconds {
+            env.panic_with_error(Error::from_contract_error(
+                ContractError::DisputeWindowExpired as u32,
+            ));
+        }
+
+        swap.status = SwapStatus::Disputed;
+        swap.dispute_timestamp = env.ledger().timestamp();
+        swap::save_swap(&env, swap_id, &swap);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("disputed"),),
+            DisputeRaisedEvent { swap_id },
+        );
+    }
+
+    /// Admin resolves a disputed swap. refunded=true refunds buyer; false completes to seller.
+    pub fn resolve_dispute(env: Env, swap_id: u64, caller: Address, refunded: bool) {
+        caller.require_auth();
+        require_admin(&env, &caller);
+
+        let mut swap = require_swap_exists(&env, swap_id);
+        require_swap_status(&env, &swap, SwapStatus::Disputed, ContractError::SwapNotDisputed);
+
+        let token_client = token::Client::new(&env, &swap.token);
+        if refunded {
+            swap.status = SwapStatus::Cancelled;
+            swap::save_swap(&env, swap_id, &swap);
+            env.storage().persistent().remove(&DataKey::ActiveSwap(swap.ip_id));
+            token_client.transfer(&env.current_contract_address(), &swap.buyer, &swap.price);
+        } else {
+            swap.status = SwapStatus::Completed;
+            swap::save_swap(&env, swap_id, &swap);
+            env.storage().persistent().remove(&DataKey::ActiveSwap(swap.ip_id));
+            let config = Self::protocol_config(&env);
+            let fee_amount = if config.protocol_fee_bps > 0 {
+                (swap.price * config.protocol_fee_bps as i128) / 10000
+            } else {
+                0
+            };
+            let seller_amount = swap.price - fee_amount;
+            if fee_amount > 0 {
+                token_client.transfer(&env.current_contract_address(), &config.treasury, &fee_amount);
+            }
+            token_client.transfer(&env.current_contract_address(), &swap.seller, &seller_amount);
+        }
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("disp_res"),),
+            DisputeResolvedEvent { swap_id, refunded },
+        );
+    }
+
+    /// Anyone can call after dispute_resolution_timeout_seconds to auto-refund the buyer.
+    pub fn auto_resolve_dispute(env: Env, swap_id: u64) {
+        let mut swap = require_swap_exists(&env, swap_id);
+        require_swap_status(&env, &swap, SwapStatus::Disputed, ContractError::SwapNotDisputed);
+
+        let config = Self::protocol_config(&env);
+        let elapsed = env.ledger().timestamp().saturating_sub(swap.dispute_timestamp);
+        if elapsed < config.dispute_resolution_timeout_seconds {
+            env.panic_with_error(Error::from_contract_error(
+                ContractError::DisputeResolutionTimeout as u32,
+            ));
+        }
+
+        swap.status = SwapStatus::Cancelled;
+        swap::save_swap(&env, swap_id, &swap);
+        env.storage().persistent().remove(&DataKey::ActiveSwap(swap.ip_id));
+
+        token::Client::new(&env, &swap.token).transfer(
+            &env.current_contract_address(),
+            &swap.buyer,
+            &swap.price,
+        );
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("disp_res"),),
+            DisputeResolvedEvent { swap_id, refunded: true },
+        );
+    }
+
     /// Cancel a pending swap. Only the seller or buyer may cancel.
     pub fn cancel_swap(env: Env, swap_id: u64, canceller: Address) {
         let mut swap = require_swap_exists(&env, swap_id);
@@ -460,6 +555,7 @@ impl AtomicSwap {
         protocol_fee_bps: u32,
         treasury: Address,
         dispute_window_seconds: u64,
+        dispute_resolution_timeout_seconds: u64,
     ) {
         if protocol_fee_bps > 10_000 {
             env.panic_with_error(Error::from_contract_error(
@@ -492,6 +588,7 @@ impl AtomicSwap {
                 protocol_fee_bps,
                 treasury,
                 dispute_window_seconds,
+                dispute_resolution_timeout_seconds,
             },
         );
     }
@@ -513,6 +610,7 @@ impl AtomicSwap {
                 protocol_fee_bps: 0,
                 treasury: env.current_contract_address(),
                 dispute_window_seconds: 86400,
+                dispute_resolution_timeout_seconds: 2_592_000, // 30 days
             })
     }
 

--- a/contracts/atomic_swap/src/tests.rs
+++ b/contracts/atomic_swap/src/tests.rs
@@ -330,4 +330,61 @@ mod tests {
         env.ledger().with_mut(|l| l.timestamp = 50);
         client.auto_resolve_dispute(&swap_id); // must panic DisputeResolutionTimeout=25
     }
+
+    #[test]
+    fn test_cancel_swap_stores_manual_cancel_reason() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let (registry_id, ip_id, _, _) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 500);
+        let contract_id = setup_swap(&env, &registry_id);
+        let client = AtomicSwapClient::new(&env, &contract_id);
+
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        client.cancel_swap(&swap_id, &seller);
+
+        let reason = client.get_cancellation_reason(&swap_id).unwrap();
+        assert_eq!(reason, soroban_sdk::Bytes::from_slice(&env, b"manual_cancel"));
+    }
+
+    #[test]
+    fn test_cancel_expired_swap_stores_expired_reason() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let (registry_id, ip_id, _, _) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 500);
+        let contract_id = setup_swap(&env, &registry_id);
+        let client = AtomicSwapClient::new(&env, &contract_id);
+
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        client.accept_swap(&swap_id);
+        // Advance past expiry (initiation timestamp=0, expiry=604800)
+        env.ledger().with_mut(|l| l.timestamp = 604801);
+        client.cancel_expired_swap(&swap_id, &buyer);
+
+        let reason = client.get_cancellation_reason(&swap_id).unwrap();
+        assert_eq!(reason, soroban_sdk::Bytes::from_slice(&env, b"expired"));
+    }
+
+    #[test]
+    fn test_no_reason_for_non_cancelled_swap() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let (registry_id, ip_id, _, _) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 500);
+        let contract_id = setup_swap(&env, &registry_id);
+        let client = AtomicSwapClient::new(&env, &contract_id);
+
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer);
+        assert!(client.get_cancellation_reason(&swap_id).is_none());
+    }
 }

--- a/contracts/atomic_swap/src/tests.rs
+++ b/contracts/atomic_swap/src/tests.rs
@@ -3,7 +3,7 @@
 mod tests {
     use ip_registry::{IpRegistry, IpRegistryClient};
     use soroban_sdk::{
-        testutils::{storage::Persistent, Address as _},
+        testutils::{storage::Persistent, Address as _, Ledger},
         token::StellarAssetClient,
         Address, BytesN, Env,
     };
@@ -182,7 +182,7 @@ mod tests {
         let client = AtomicSwapClient::new(&env, &contract_id);
         let treasury = Address::generate(&env);
 
-        client.admin_set_protocol_config(&250u32, &treasury, &3_600u64);
+        client.admin_set_protocol_config(&250u32, &treasury, &3_600u64, &2_592_000u64);
 
         let cached = env
             .storage()
@@ -206,8 +206,8 @@ mod tests {
         let treasury_a = Address::generate(&env);
         let treasury_b = Address::generate(&env);
 
-        client.admin_set_protocol_config(&100u32, &treasury_a, &900u64);
-        client.admin_set_protocol_config(&500u32, &treasury_b, &7_200u64);
+        client.admin_set_protocol_config(&100u32, &treasury_a, &900u64, &2_592_000u64);
+        client.admin_set_protocol_config(&500u32, &treasury_b, &7_200u64, &2_592_000u64);
 
         let cached = env
             .storage()
@@ -244,7 +244,7 @@ mod tests {
         let client = AtomicSwapClient::new(&env, &contract_id);
 
         // 250 bps = 2.5% fee
-        client.admin_set_protocol_config(&250u32, &treasury, &86400u64);
+        client.admin_set_protocol_config(&250u32, &treasury, &86400u64, &2_592_000u64);
 
         let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &price, &buyer);
         client.accept_swap(&swap_id);
@@ -264,5 +264,70 @@ mod tests {
         assert_eq!(event.swap_id, swap_id);
         assert_eq!(event.fee_amount, expected_fee);
         assert_eq!(event.seller_amount, expected_seller);
+    }
+
+    #[test]
+    fn test_auto_resolve_dispute_refunds_buyer_after_timeout() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let (registry_id, ip_id, _, _) = setup_registry(&env, &seller);
+        let price = 1000_i128;
+        let token_id = setup_token(&env, &admin, &buyer, price);
+
+        let contract_id = setup_swap(&env, &registry_id);
+        let client = AtomicSwapClient::new(&env, &contract_id);
+
+        // 1-second dispute window, 100-second resolution timeout
+        client.admin_set_protocol_config(&0u32, &treasury, &1u64, &100u64);
+
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &price, &buyer);
+        client.accept_swap(&swap_id);
+
+        // Advance time past dispute window so buyer can raise dispute
+        env.ledger().with_mut(|l| l.timestamp = 10);
+        // Wait — dispute window is 1s, accept_timestamp is 0, elapsed = 10 >= 1 → expired
+        // So we need to raise dispute BEFORE the window expires. Reset to within window.
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        client.raise_dispute(&swap_id);
+
+        // Advance past resolution timeout (100s from dispute_timestamp=0)
+        env.ledger().with_mut(|l| l.timestamp = 101);
+        client.auto_resolve_dispute(&swap_id);
+
+        assert_eq!(client.get_swap(&swap_id).unwrap().status, SwapStatus::Cancelled);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #25)")]
+    fn test_auto_resolve_dispute_rejected_before_timeout() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let (registry_id, ip_id, _, _) = setup_registry(&env, &seller);
+        let price = 500_i128;
+        let token_id = setup_token(&env, &admin, &buyer, price);
+
+        let contract_id = setup_swap(&env, &registry_id);
+        let client = AtomicSwapClient::new(&env, &contract_id);
+
+        // 1-second dispute window, 1000-second resolution timeout
+        client.admin_set_protocol_config(&0u32, &treasury, &1u64, &1000u64);
+
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &price, &buyer);
+        client.accept_swap(&swap_id);
+        client.raise_dispute(&swap_id);
+
+        // Only 50s elapsed — timeout not reached
+        env.ledger().with_mut(|l| l.timestamp = 50);
+        client.auto_resolve_dispute(&swap_id); // must panic DisputeResolutionTimeout=25
     }
 }

--- a/contracts/atomic_swap/src/tests.rs
+++ b/contracts/atomic_swap/src/tests.rs
@@ -226,4 +226,43 @@ mod tests {
         assert_eq!(persisted, cached);
         assert_eq!(client.get_protocol_config(), cached);
     }
+
+    #[test]
+    fn test_key_revealed_event_fee_breakdown() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let (registry_id, ip_id, secret, blinding) = setup_registry(&env, &seller);
+        let price = 1000_i128;
+        let token_id = setup_token(&env, &admin, &buyer, price);
+
+        let contract_id = setup_swap(&env, &registry_id);
+        let client = AtomicSwapClient::new(&env, &contract_id);
+
+        // 250 bps = 2.5% fee
+        client.admin_set_protocol_config(&250u32, &treasury, &86400u64);
+
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &price, &buyer);
+        client.accept_swap(&swap_id);
+        client.reveal_key(&swap_id, &seller, &secret, &blinding);
+
+        let expected_fee = (price * 250) / 10000; // 25
+        let expected_seller = price - expected_fee;  // 975
+
+        let events = env.events().all();
+        let key_rev_event = events.iter().find(|(_, topics, _)| {
+            topics == &soroban_sdk::vec![&env, soroban_sdk::symbol_short!("key_rev").into()]
+        });
+        assert!(key_rev_event.is_some(), "key_rev event not found");
+
+        let (_, _, data) = key_rev_event.unwrap();
+        let event: crate::KeyRevealedEvent = soroban_sdk::FromVal::from_val(&env, &data);
+        assert_eq!(event.swap_id, swap_id);
+        assert_eq!(event.fee_amount, expected_fee);
+        assert_eq!(event.seller_amount, expected_seller);
+    }
 }

--- a/contracts/atomic_swap/src/types.rs
+++ b/contracts/atomic_swap/src/types.rs
@@ -91,6 +91,8 @@ pub struct SwapCancelledEvent {
 #[derive(Clone, Debug, PartialEq)]
 pub struct KeyRevealedEvent {
     pub swap_id: u64,
+    pub seller_amount: i128,
+    pub fee_amount: i128,
 }
 
 /// Payload published when protocol fee is deducted on swap completion.

--- a/contracts/atomic_swap/src/types.rs
+++ b/contracts/atomic_swap/src/types.rs
@@ -28,6 +28,8 @@ pub enum DataKey {
     IpSwaps(u64),
     /// Whether the contract is paused (blocks initiate_swap and accept_swap).
     Paused,
+    /// Maps swap_id → cancellation reason bytes. Set only when a swap is cancelled.
+    CancelReason(u64),
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────

--- a/contracts/atomic_swap/src/types.rs
+++ b/contracts/atomic_swap/src/types.rs
@@ -55,6 +55,8 @@ pub struct SwapRecord {
     /// if reveal_key has not been called. Set at initiation time.
     pub expiry: u64,
     pub accept_timestamp: u64,
+    /// Ledger timestamp when the dispute was raised. 0 if not disputed.
+    pub dispute_timestamp: u64,
 }
 
 // ── Events ────────────────────────────────────────────────────────────────────
@@ -123,4 +125,5 @@ pub struct ProtocolConfig {
     pub protocol_fee_bps: u32,  // 0-10000 (0.00% - 100.00%)
     pub treasury: Address,
     pub dispute_window_seconds: u64,
+    pub dispute_resolution_timeout_seconds: u64,
 }

--- a/contracts/atomic_swap/src/validation.rs
+++ b/contracts/atomic_swap/src/validation.rs
@@ -267,6 +267,7 @@ mod tests {
             status: SwapStatus::Pending,
             expiry: 0,
             accept_timestamp: 0,
+            dispute_timestamp: 0,
         };
         // Should not panic
         require_swap_status(
@@ -290,6 +291,7 @@ mod tests {
             status: SwapStatus::Accepted,
             expiry: 0,
             accept_timestamp: 0,
+            dispute_timestamp: 0,
         };
         require_swap_status(
             &env,
@@ -312,6 +314,7 @@ mod tests {
             status: SwapStatus::Pending,
             expiry: 0,
             accept_timestamp: 0,
+            dispute_timestamp: 0,
         };
         // Should not panic
         require_seller(&env, &seller, &swap);
@@ -332,6 +335,7 @@ mod tests {
             status: SwapStatus::Pending,
             expiry: 0,
             accept_timestamp: 0,
+            dispute_timestamp: 0,
         };
         require_seller(&env, &not_seller, &swap);
     }
@@ -349,6 +353,7 @@ mod tests {
             status: SwapStatus::Pending,
             expiry: 0,
             accept_timestamp: 0,
+            dispute_timestamp: 0,
         };
         // Should not panic
         require_buyer(&env, &buyer, &swap);
@@ -369,6 +374,7 @@ mod tests {
             status: SwapStatus::Pending,
             expiry: 0,
             accept_timestamp: 0,
+            dispute_timestamp: 0,
         };
         require_buyer(&env, &not_buyer, &swap);
     }
@@ -386,6 +392,7 @@ mod tests {
             status: SwapStatus::Pending,
             expiry: 0,
             accept_timestamp: 0,
+            dispute_timestamp: 0,
         };
         // Should not panic
         require_seller_or_buyer(&env, &seller, &swap);
@@ -404,6 +411,7 @@ mod tests {
             status: SwapStatus::Pending,
             expiry: 0,
             accept_timestamp: 0,
+            dispute_timestamp: 0,
         };
         // Should not panic
         require_seller_or_buyer(&env, &buyer, &swap);
@@ -425,6 +433,7 @@ mod tests {
             status: SwapStatus::Pending,
             expiry: 0,
             accept_timestamp: 0,
+            dispute_timestamp: 0,
         };
         require_seller_or_buyer(&env, &neither, &swap);
     }
@@ -441,6 +450,7 @@ mod tests {
             status: SwapStatus::Accepted,
             expiry: 0, // Expired (timestamp is > 0)
             accept_timestamp: 0,
+            dispute_timestamp: 0,
         };
         // Should not panic
         require_swap_expired(&env, &swap);
@@ -459,6 +469,7 @@ mod tests {
             status: SwapStatus::Accepted,
             expiry: u64::MAX, // Far in the future
             accept_timestamp: 0,
+            dispute_timestamp: 0,
         };
         require_swap_expired(&env, &swap);
     }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,481 @@
+openapi: 3.0.3
+info:
+  title: Atomic Patent API
+  description: Machine-readable specification for the Atomic Patent Soroban smart contract interface.
+  version: 1.0.0
+
+tags:
+  - name: IP Registry
+    description: Commit and query intellectual property records
+  - name: Atomic Swap
+    description: Trustless patent sale via atomic swap
+
+paths:
+  /ip/commit:
+    post:
+      tags: [IP Registry]
+      summary: Timestamp a new IP commitment
+      operationId: commitIp
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CommitIpRequest'
+      responses:
+        '200':
+          description: IP committed successfully, returns assigned ip_id
+          content:
+            application/json:
+              schema:
+                type: integer
+                format: int64
+        '400':
+          description: Invalid request (zero hash, duplicate hash)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /ip/{ip_id}:
+    get:
+      tags: [IP Registry]
+      summary: Retrieve an IP record by ID
+      operationId: getIp
+      parameters:
+        - name: ip_id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: IP record found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IpRecord'
+        '404':
+          description: IP record not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /ip/transfer:
+    post:
+      tags: [IP Registry]
+      summary: Transfer IP ownership to a new address
+      operationId: transferIp
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransferIpRequest'
+      responses:
+        '200':
+          description: Ownership transferred successfully
+        '404':
+          description: IP record not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /ip/verify:
+    post:
+      tags: [IP Registry]
+      summary: Verify a Pedersen commitment
+      operationId: verifyCommitment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyCommitmentRequest'
+      responses:
+        '200':
+          description: Verification result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VerifyCommitmentResponse'
+        '404':
+          description: IP record not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /ip/owner/{owner}:
+    get:
+      tags: [IP Registry]
+      summary: List all IP IDs owned by a Stellar address
+      operationId: listIpByOwner
+      parameters:
+        - name: owner
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: List of IP IDs (null if none)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListIpByOwnerResponse'
+
+  /swap/initiate:
+    post:
+      tags: [Atomic Swap]
+      summary: Seller initiates a patent sale
+      operationId: initiateSwap
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InitiateSwapRequest'
+      responses:
+        '200':
+          description: Swap initiated, returns swap_id
+          content:
+            application/json:
+              schema:
+                type: integer
+                format: int64
+        '400':
+          description: Seller is not IP owner or active swap exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /swap/{swap_id}/accept:
+    post:
+      tags: [Atomic Swap]
+      summary: Buyer accepts a pending swap
+      operationId: acceptSwap
+      parameters:
+        - name: swap_id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AcceptSwapRequest'
+      responses:
+        '200':
+          description: Swap accepted
+        '400':
+          description: Swap not in Pending state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Swap not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /swap/{swap_id}/reveal:
+    post:
+      tags: [Atomic Swap]
+      summary: Seller reveals the decryption key
+      operationId: revealKey
+      parameters:
+        - name: swap_id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RevealKeyRequest'
+      responses:
+        '200':
+          description: Key revealed, swap completed
+        '400':
+          description: Swap not in Accepted state or caller is not seller
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Swap not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /swap/{swap_id}/cancel:
+    post:
+      tags: [Atomic Swap]
+      summary: Cancel a pending swap
+      operationId: cancelSwap
+      parameters:
+        - name: swap_id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CancelSwapRequest'
+      responses:
+        '200':
+          description: Swap cancelled
+        '400':
+          description: Swap not in Pending state or canceller is not seller/buyer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Swap not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /swap/{swap_id}/cancel-expired:
+    post:
+      tags: [Atomic Swap]
+      summary: Buyer cancels an Accepted swap after expiry
+      operationId: cancelExpiredSwap
+      parameters:
+        - name: swap_id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CancelExpiredSwapRequest'
+      responses:
+        '200':
+          description: Expired swap cancelled
+        '400':
+          description: Swap not expired, not Accepted, or caller is not buyer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Swap not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /swap/{swap_id}:
+    get:
+      tags: [Atomic Swap]
+      summary: Read a swap record by ID
+      operationId: getSwap
+      parameters:
+        - name: swap_id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Swap record found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SwapRecord'
+        '404':
+          description: Swap not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  schemas:
+    CommitIpRequest:
+      type: object
+      required: [owner, commitment_hash]
+      properties:
+        owner:
+          type: string
+          description: Stellar address of the IP owner (must sign the transaction)
+        commitment_hash:
+          type: string
+          description: 32-byte Pedersen commitment hash, hex-encoded
+
+    IpRecord:
+      type: object
+      required: [ip_id, owner, commitment_hash, timestamp, revoked]
+      properties:
+        ip_id:
+          type: integer
+          format: int64
+        owner:
+          type: string
+        commitment_hash:
+          type: string
+        timestamp:
+          type: integer
+          format: int64
+        revoked:
+          type: boolean
+          description: Whether the IP record has been revoked
+
+    TransferIpRequest:
+      type: object
+      required: [ip_id, new_owner]
+      properties:
+        ip_id:
+          type: integer
+          format: int64
+        new_owner:
+          type: string
+
+    VerifyCommitmentRequest:
+      type: object
+      required: [ip_id, secret, blinding_factor]
+      properties:
+        ip_id:
+          type: integer
+          format: int64
+        secret:
+          type: string
+          description: 32-byte secret, hex-encoded
+        blinding_factor:
+          type: string
+          description: 32-byte blinding factor, hex-encoded
+
+    VerifyCommitmentResponse:
+      type: object
+      required: [valid]
+      properties:
+        valid:
+          type: boolean
+          description: true if sha256(secret || blinding_factor) matches the stored commitment hash
+
+    ListIpByOwnerResponse:
+      type: object
+      properties:
+        ip_ids:
+          type: array
+          items:
+            type: integer
+            format: int64
+          nullable: true
+
+    SwapStatus:
+      type: string
+      enum: [Pending, Accepted, Completed, Cancelled]
+
+    SwapRecord:
+      type: object
+      required: [ip_id, ip_registry_id, seller, buyer, price, token, status, expiry]
+      properties:
+        ip_id:
+          type: integer
+          format: int64
+        ip_registry_id:
+          type: string
+        seller:
+          type: string
+        buyer:
+          type: string
+        price:
+          type: integer
+          format: int64
+          description: Price in stroops (1 XLM = 10_000_000 stroops)
+        token:
+          type: string
+        status:
+          $ref: '#/components/schemas/SwapStatus'
+        expiry:
+          type: integer
+          format: int64
+          description: Ledger timestamp after which buyer may cancel an Accepted swap
+
+    InitiateSwapRequest:
+      type: object
+      required: [ip_registry_id, ip_id, seller, price, buyer, token]
+      properties:
+        ip_registry_id:
+          type: string
+        ip_id:
+          type: integer
+          format: int64
+        seller:
+          type: string
+        price:
+          type: integer
+          format: int64
+        buyer:
+          type: string
+        token:
+          type: string
+          description: Stellar asset contract address for the payment token
+
+    AcceptSwapRequest:
+      type: object
+      required: [buyer]
+      properties:
+        buyer:
+          type: string
+
+    RevealKeyRequest:
+      type: object
+      required: [caller, secret, blinding_factor]
+      properties:
+        caller:
+          type: string
+        secret:
+          type: string
+          description: 32-byte secret, hex-encoded
+        blinding_factor:
+          type: string
+          description: 32-byte blinding factor, hex-encoded
+
+    CancelSwapRequest:
+      type: object
+      required: [canceller]
+      properties:
+        canceller:
+          type: string
+
+    CancelExpiredSwapRequest:
+      type: object
+      required: [caller]
+      properties:
+        caller:
+          type: string
+
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string


### PR DESCRIPTION
## Summary

This PR resolves four issues across the `atomic_swap` contract and `api-server`:

---

### 255 — Add Swap Fee Breakdown in Events

**Files:** `contracts/atomic_swap/src/lib.rs`, `contracts/atomic_swap/src/types.rs`, `contracts/atomic_swap/src/tests.rs`

- Added `seller_amount: i128` and `fee_amount: i128` fields to `KeyRevealedEvent` in both `types.rs` and `lib.rs`
- Updated `reveal_key` to populate both fields in the emitted `key_rev` event (values were already computed, just not included)
- Added test `test_key_revealed_event_fee_breakdown`: sets 250 bps fee, runs a full swap, asserts `fee_amount = 25` and `seller_amount = 975` on a price of 1000

---

### 256 — Implement Swap Dispute Resolution Timeout

**Files:** `contracts/atomic_swap/src/lib.rs`, `contracts/atomic_swap/src/types.rs`, `contracts/atomic_swap/src/validation.rs`, `contracts/atomic_swap/src/tests.rs`

- Added `dispute_resolution_timeout_seconds: u64` to `ProtocolConfig` (default **30 days** = 2,592,000s)
- Added `dispute_timestamp: u64` to `SwapRecord` (set when dispute is raised, 0 otherwise)
- Added `DisputeResolutionTimeout = 25` to `ContractError`
- Implemented `raise_dispute(swap_id)`: buyer-only, swap must be `Accepted`, must be called within `dispute_window_seconds` of `accept_timestamp`
- Implemented `resolve_dispute(swap_id, caller, refunded)`: admin-only; `refunded=true` → `Cancelled` + refund buyer; `false` → `Completed` + pay seller with fee deduction
- Implemented `auto_resolve_dispute(swap_id)`: permissionless; requires swap is `Disputed` and `dispute_resolution_timeout_seconds` has elapsed since `dispute_timestamp`; auto-refunds buyer
- Updated `admin_set_protocol_config` signature to accept `dispute_resolution_timeout_seconds`
- Updated all `SwapRecord` struct literals in `validation.rs` to include `dispute_timestamp: 0`
- Added tests: `test_auto_resolve_dispute_refunds_buyer_after_timeout` and `test_auto_resolve_dispute_rejected_before_timeout`

---

### 257 — Add Swap Cancellation Reason Tracking

**Files:** `contracts/atomic_swap/src/lib.rs`, `contracts/atomic_swap/src/types.rs`, `contracts/atomic_swap/src/tests.rs`

- Added `CancelReason(u64)` variant to `DataKey` in both `types.rs` and `lib.rs`
- Each cancellation path now writes a reason to `DataKey::CancelReason(swap_id)`:
  - `cancel_swap` → `"manual_cancel"`
  - `cancel_expired_swap` → `"expired"`
  - `resolve_dispute` (refund path) → `"dispute_refund"`
  - `auto_resolve_dispute` → `"dispute_timeout"`
- Implemented `get_cancellation_reason(swap_id) -> Option<Bytes>`: returns `None` for non-cancelled swaps
- Added tests: `test_cancel_swap_stores_manual_cancel_reason`, `test_cancel_expired_swap_stores_expired_reason`, `test_no_reason_for_non_cancelled_swap`

---

### 258 — Implement OpenAPI Schema Validation

**Files:** `docs/openapi.yaml`, `api-server/src/main.rs`, `api-server/Cargo.toml`, `client/package.json`, `client/openapitools.json`, `client/README.md`

- Added `docs/openapi.yaml`: full OpenAPI 3.0.3 spec covering all 11 routes, all request/response schemas, path parameters, and error responses — mirrors the utoipa-generated `/openapi.json`
- Added `require_json_content_type` Axum middleware: rejects `POST`/`PUT`/`PATCH` requests without `Content-Type: application/json` with `415 Unsupported Media Type`
- Extracted `build_app()` helper for testability
- Added 5 schema compliance tests: content-type rejection, wrong content-type, valid JSON passes, GET bypasses check, `/openapi.json` endpoint returns parseable spec with correct `info.title`
- Added `tower` dev-dependency to `api-server/Cargo.toml`
- Added `client/` directory with `package.json` (npm scripts: `generate` via `openapi-typescript` for lightweight type definitions, `generate:sdk` via `openapi-generator-cli` for full `typescript-fetch` SDK)

---

Closes #255
Closes #256
Closes #257
Closes #258