### PR TITLE
docs(security): add structured Dispute Resolution section to threat m…

### DIFF
--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -161,76 +161,83 @@ This document analyzes potential attack vectors in the Atomic Patent swap mechan
 
 **Status**: ✅ Mitigated
 
-## Dispute Resolution Threat Model
+## Dispute Resolution
 
 ### Overview
 
-The dispute resolution feature allows a designated admin (or multi-sig admin group) to adjudicate contested swaps — for example, when a buyer claims the revealed key is invalid despite on-chain verification passing, or when off-chain delivery of associated materials is disputed.
+The dispute resolution mechanism allows a designated admin to adjudicate contested swaps where on-chain verification alone is insufficient — e.g. a buyer claims the revealed key does not decrypt the promised IP, or off-chain delivery of associated materials is disputed. The admin can rule in favour of either party, triggering fund release or refund. Because this introduces a privileged role, it is the highest-risk surface in the protocol and requires careful operational controls.
 
 ---
 
-### 13. Admin Collusion
+### Attack Vectors
 
-**Scenario**: A single admin account is compromised or acts maliciously, ruling in favour of one party to steal funds or IP.
+#### 13. Admin Collusion
 
-**Impact**: Fraudulent dispute outcomes; loss of buyer funds or seller IP rights.
+**Scenario**: A single admin account is compromised or acts maliciously, ruling in favour of one party to steal funds or IP rights.
 
-**Mitigation**:
-- Admin role must be held by a **multi-sig account** (M-of-N threshold, recommended 2-of-3 minimum)
-- All admin actions are recorded on-chain with the admin's address and ledger timestamp
-- A time-lock delay (e.g. 48 hours) between dispute ruling and fund release gives parties time to escalate
-- Governance upgrade path: admin key can be rotated via on-chain vote in future versions
+**Impact**: Fraudulent dispute outcomes; direct loss of buyer funds or seller IP.
 
-**Operator Recommendation**: Deploy with a multi-sig admin from day one. Never use a single EOA as the dispute admin on mainnet.
+**Mitigations**:
+- Admin role must be a **multi-sig account** (minimum 2-of-3 threshold; 3-of-5 recommended for high-value deployments)
+- All admin rulings are recorded on-chain with the admin address and ledger timestamp — fully auditable
+- A **48-hour time-lock** between ruling and fund release gives the losing party time to escalate off-chain
+- Admin key rotation is supported via contract upgrade path; rotation procedure must be documented before mainnet
 
-**Status**: ⚠️ Partially mitigated (requires operator configuration)
-
----
-
-### 14. False Dispute Submission
-
-**Scenario**: A buyer or seller raises a dispute in bad faith — e.g. a buyer disputes a valid key reveal to delay payment release, or a seller disputes to stall a refund.
-
-**Impact**: Legitimate counterparty funds locked; griefing / denial-of-service on the swap.
-
-**Mitigation**:
-- Disputes require **on-chain evidence submission** (e.g. a hash of supporting material stored via `dispute_evidence` field)
-- A non-refundable **dispute bond** is required to open a dispute; bond is forfeited if the dispute is ruled frivolous
-- Dispute window is bounded: disputes must be raised within `dispute_period` ledgers after the triggering event
-- Repeated frivolous disputes from the same address can be flagged and rate-limited by the admin
-
-**Operator Recommendation**: Set a meaningful dispute bond (e.g. 10% of swap price, minimum 1 XLM) to deter bad-faith filings. Publish the evidence-submission format in your integration guide.
-
-**Status**: ⚠️ Partially mitigated (requires operator configuration)
+**Status**: ⚠️ Partially mitigated — depends on operator deploying multi-sig correctly
 
 ---
 
-### 15. Timeout Abuse
+#### 14. False Dispute Submission
 
-**Scenario**: A party deliberately stalls the dispute process — e.g. admin never rules, or a party never submits evidence — to keep funds locked indefinitely or force the other party to abandon their claim.
+**Scenario**: A party raises a dispute in bad faith — buyer disputes a valid key reveal to delay payment release, or seller disputes to stall a refund.
 
-**Impact**: Funds locked beyond the intended swap expiry; effective denial of refund or payment.
+**Impact**: Counterparty funds locked; griefing / DoS against legitimate swap completion.
 
-**Mitigation**:
-- **Auto-resolution on timeout**: if the admin has not ruled within `dispute_timeout` ledgers, the contract automatically resolves in favour of the buyer (refund) as the safe default
-- Evidence submission deadline is enforced on-chain; failure to submit evidence within the window is treated as conceding the dispute
-- All timeout thresholds are set at contract initialisation and cannot be changed without a contract upgrade (preventing admin from extending timeouts to stall)
+**Mitigations**:
+- Disputes require an **on-chain evidence hash** (`dispute_evidence` field) submitted at filing time — no evidence, no dispute
+- A **non-refundable dispute bond** (minimum 1 XLM or 10% of swap price, whichever is greater) is forfeited if the dispute is ruled frivolous
+- Disputes must be filed within `dispute_period` ledgers of the triggering event; late filings are rejected by the contract
+- Repeated frivolous filings from the same address are rate-limited by the admin
 
-**Operator Recommendation**: Set `dispute_timeout` conservatively (e.g. 14 days / ~120,960 ledgers). Document the auto-resolution default clearly so both parties understand the incentive to act promptly.
-
-**Status**: ✅ Mitigated (when timeout parameters are correctly configured)
+**Status**: ⚠️ Partially mitigated — bond amount and evidence format must be configured by operator
 
 ---
 
-### Dispute Resolution: Operator Recommendations Summary
+#### 15. Timeout Abuse
 
-| Concern | Recommended Configuration |
+**Scenario**: A party deliberately stalls — admin never rules, or a party withholds evidence — to keep funds locked indefinitely or force the counterparty to abandon their claim.
+
+**Impact**: Funds locked beyond intended swap expiry; effective denial of refund or payment.
+
+**Mitigations**:
+- **Auto-resolution on timeout**: if the admin has not ruled within `dispute_timeout` ledgers, the contract automatically refunds the buyer as the safe default
+- Evidence submission deadline is enforced on-chain; failure to submit within the window is treated as conceding the dispute
+- `dispute_timeout` is set at contract initialisation and is **immutable** — admin cannot extend it to stall resolution
+
+**Status**: ✅ Mitigated — provided `dispute_timeout` is set correctly at deploy time
+
+---
+
+### Residual Risks
+
+| Risk | Detail |
 |---|---|
-| Admin collusion | Multi-sig admin, minimum 2-of-3 |
-| False disputes | Require evidence hash on submission; set dispute bond ≥ 1 XLM |
-| Timeout abuse | Set `dispute_timeout` ≤ 14 days; auto-resolve to buyer refund |
-| Audit trail | Log all dispute events (open, evidence, ruling, auto-resolve) on-chain |
-| Key rotation | Plan admin key rotation procedure before mainnet launch |
+| Off-chain evidence integrity | The contract stores only a hash of evidence; the underlying data lives off-chain and could be lost or withheld. Operators should require evidence to be pinned to a content-addressed store (e.g. IPFS). |
+| Admin key compromise post-ruling | If the admin key is compromised after a ruling but before the time-lock expires, an attacker could attempt to reverse the ruling. Multi-sig and time-lock together reduce but do not eliminate this window. |
+| Governance capture | In future versions where admin is controlled by token vote, a majority token holder could capture dispute outcomes. Quorum and time-lock requirements must be enforced at the governance layer. |
+
+---
+
+### Operator Recommendations
+
+| Concern | Required Action |
+|---|---|
+| Admin collusion | Deploy with multi-sig admin (2-of-3 minimum); **never** use a single EOA on mainnet |
+| False disputes | Require evidence hash at submission; set bond ≥ max(1 XLM, 10% of swap price) |
+| Timeout abuse | Set `dispute_timeout` ≤ 14 days (~120,960 ledgers); verify auto-resolve defaults to buyer refund |
+| Audit trail | Emit on-chain events for all state transitions: `DisputeOpened`, `EvidenceSubmitted`, `DisputeRuled`, `DisputeAutoResolved` |
+| Key rotation | Define and test admin key rotation procedure before mainnet launch; store rotation policy in governance docs |
+| Evidence availability | Require disputing parties to pin evidence to IPFS or equivalent; store CID in `dispute_evidence` field |
 
 ---
 


### PR DESCRIPTION
Closes #270 

The threat model in docs/threat-model.md does not cover the new dispute resolution feature. Attack vectors and mitigations are undocumented.\n\n## Tasks:\n- Update docs/threat-model.md with dispute resolution section\n- Document attack vectors: admin collusion, false disputes, timeout abuse\n- Document mitigations: multi-sig admin, dispute evidence requirements, timeout auto-resolution\n- Add recommendations for operators\n\nLabels: documentation, security\nPriority: Medium