### PR TITLE
feat: swap arbitration, dispute evidence, tiered pricing, GraphQL API…

### DIFF
--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -22,3 +22,5 @@ tower = "0.4"
 tower-http = { version = "0.5", features = ["trace"] }
 http-body-util = "0.1"
 once_cell = "1"
+async-graphql = { version = "7", features = ["chrono"] }
+async-graphql-axum = "7"

--- a/api-server/src/graphql.rs
+++ b/api-server/src/graphql.rs
@@ -1,0 +1,140 @@
+use async_graphql::{Context, EmptyMutation, EmptySubscription, Object, Schema, SimpleObject};
+
+// ── GraphQL Types ─────────────────────────────────────────────────────────────
+
+/// An intellectual property record.
+#[derive(SimpleObject, Clone)]
+pub struct IpRecord {
+    pub ip_id: u64,
+    pub owner: String,
+    pub commitment_hash: String,
+    pub timestamp: u64,
+    pub revoked: bool,
+}
+
+/// Status of an atomic swap.
+#[derive(async_graphql::Enum, Copy, Clone, Eq, PartialEq)]
+pub enum SwapStatus {
+    Pending,
+    Accepted,
+    Completed,
+    Disputed,
+    Cancelled,
+}
+
+/// An atomic swap record.
+#[derive(SimpleObject, Clone)]
+pub struct SwapRecord {
+    pub swap_id: u64,
+    pub ip_id: u64,
+    pub seller: String,
+    pub buyer: String,
+    /// Price in stroops (1 XLM = 10_000_000 stroops)
+    pub price: String,
+    pub token: String,
+    pub status: SwapStatus,
+    pub expiry: u64,
+    /// Optional arbitrator address for third-party dispute resolution.
+    pub arbitrator: Option<String>,
+}
+
+// ── Query Root ────────────────────────────────────────────────────────────────
+
+pub struct QueryRoot;
+
+#[Object]
+impl QueryRoot {
+    /// Fetch an IP record by its ID.
+    async fn ip(&self, _ctx: &Context<'_>, ip_id: u64) -> Option<IpRecord> {
+        // TODO: wire up to Soroban RPC
+        let _ = ip_id;
+        None
+    }
+
+    /// Fetch a swap record by its ID.
+    async fn swap(&self, _ctx: &Context<'_>, swap_id: u64) -> Option<SwapRecord> {
+        // TODO: wire up to Soroban RPC
+        let _ = swap_id;
+        None
+    }
+
+    /// List all swap IDs for a given seller address.
+    async fn swaps_by_seller(&self, _ctx: &Context<'_>, seller: String) -> Vec<u64> {
+        // TODO: wire up to Soroban RPC
+        let _ = seller;
+        vec![]
+    }
+
+    /// List all swap IDs for a given buyer address.
+    async fn swaps_by_buyer(&self, _ctx: &Context<'_>, buyer: String) -> Vec<u64> {
+        // TODO: wire up to Soroban RPC
+        let _ = buyer;
+        vec![]
+    }
+
+    /// List all swap IDs ever created for a given IP.
+    async fn swaps_by_ip(&self, _ctx: &Context<'_>, ip_id: u64) -> Vec<u64> {
+        // TODO: wire up to Soroban RPC
+        let _ = ip_id;
+        vec![]
+    }
+
+    /// Retrieve all dispute evidence hashes for a swap.
+    async fn dispute_evidence(&self, _ctx: &Context<'_>, swap_id: u64) -> Vec<String> {
+        // TODO: wire up to Soroban RPC
+        let _ = swap_id;
+        vec![]
+    }
+}
+
+// ── Schema ────────────────────────────────────────────────────────────────────
+
+pub type AtomicIpSchema = Schema<QueryRoot, EmptyMutation, EmptySubscription>;
+
+pub fn build_schema() -> AtomicIpSchema {
+    Schema::build(QueryRoot, EmptyMutation, EmptySubscription).finish()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_graphql::Request;
+
+    #[tokio::test]
+    async fn test_graphql_ip_query_returns_null_for_unknown() {
+        let schema = build_schema();
+        let res = schema.execute(Request::new("{ ip(ipId: 999) { ipId owner } }")).await;
+        assert!(res.errors.is_empty(), "unexpected errors: {:?}", res.errors);
+        assert_eq!(res.data.to_string(), r#"{"ip":null}"#);
+    }
+
+    #[tokio::test]
+    async fn test_graphql_swap_query_returns_null_for_unknown() {
+        let schema = build_schema();
+        let res = schema.execute(Request::new("{ swap(swapId: 1) { swapId status } }")).await;
+        assert!(res.errors.is_empty(), "unexpected errors: {:?}", res.errors);
+        assert_eq!(res.data.to_string(), r#"{"swap":null}"#);
+    }
+
+    #[tokio::test]
+    async fn test_graphql_swaps_by_seller_returns_empty_list() {
+        let schema = build_schema();
+        let res = schema
+            .execute(Request::new(r#"{ swapsBySeller(seller: "GABC") }"#))
+            .await;
+        assert!(res.errors.is_empty(), "unexpected errors: {:?}", res.errors);
+        assert_eq!(res.data.to_string(), r#"{"swapsBySeller":[]}"#);
+    }
+
+    #[tokio::test]
+    async fn test_graphql_dispute_evidence_returns_empty_list() {
+        let schema = build_schema();
+        let res = schema
+            .execute(Request::new("{ disputeEvidence(swapId: 1) }"))
+            .await;
+        assert!(res.errors.is_empty(), "unexpected errors: {:?}", res.errors);
+        assert_eq!(res.data.to_string(), r#"{"disputeEvidence":[]}"#);
+    }
+}

--- a/api-server/src/main.rs
+++ b/api-server/src/main.rs
@@ -2,8 +2,10 @@ use axum::{routing::get, routing::post, Router};
 use axum::middleware;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
+use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 
 mod auth;
+mod graphql;
 mod handlers;
 mod metrics;
 mod schemas;
@@ -57,6 +59,14 @@ mod webhook;
 )]
 pub struct ApiDoc;
 
+/// GraphQL endpoint — accepts POST requests with a GraphQL query body.
+async fn graphql_handler(
+    axum::extract::State(schema): axum::extract::State<graphql::AtomicIpSchema>,
+    req: GraphQLRequest,
+) -> GraphQLResponse {
+    schema.execute(req.into_inner()).await.into()
+}
+
 /// Middleware: reject POST/PUT/PATCH requests whose body is non-empty but lacks
 /// `Content-Type: application/json`.
 async fn require_json_content_type(req: Request<Body>, next: Next) -> Result<Response, StatusCode> {
@@ -78,9 +88,12 @@ async fn require_json_content_type(req: Request<Body>, next: Next) -> Result<Res
 async fn main() {
     metrics::init();
 
+    let schema = graphql::build_schema();
+
     let app = Router::new()
         .merge(SwaggerUi::new("/docs").url("/openapi.json", ApiDoc::openapi()))
         .route("/metrics", get(metrics::metrics_handler))
+        .route("/graphql", post(graphql_handler))
         .route("/ip/commit", post(handlers::commit_ip))
         .route("/ip/{ip_id}", get(handlers::get_ip))
         .route("/ip/transfer", post(handlers::transfer_ip))
@@ -92,6 +105,7 @@ async fn main() {
         .route("/swap/{swap_id}/cancel", post(handlers::cancel_swap))
         .route("/swap/{swap_id}/cancel-expired", post(handlers::cancel_expired_swap))
         .route("/swap/{swap_id}", get(handlers::get_swap))
+        .with_state(schema)
         .layer(middleware::from_fn(metrics::track));
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await.unwrap();
@@ -102,7 +116,9 @@ async fn main() {
 }
 
 fn build_app() -> Router {
+    let schema = graphql::build_schema();
     Router::new()
+        .route("/graphql", post(graphql_handler))
         .route("/ip/commit", post(handlers::commit_ip))
         .route("/ip/{ip_id}", get(handlers::get_ip))
         .route("/ip/transfer", post(handlers::transfer_ip))
@@ -114,6 +130,7 @@ fn build_app() -> Router {
         .route("/swap/{swap_id}/cancel", post(handlers::cancel_swap))
         .route("/swap/{swap_id}/cancel-expired", post(handlers::cancel_expired_swap))
         .route("/swap/{swap_id}", get(handlers::get_swap))
+        .with_state(schema)
         .layer(middleware::from_fn(require_json_content_type))
 }
 

--- a/contracts/atomic_swap/src/arbitration_tests.rs
+++ b/contracts/atomic_swap/src/arbitration_tests.rs
@@ -1,0 +1,289 @@
+#[cfg(test)]
+mod arbitration_tests {
+    use ip_registry::{IpRegistry, IpRegistryClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, BytesN, Env,
+    };
+
+    use crate::{AtomicSwap, AtomicSwapClient, SwapStatus};
+
+    fn setup_registry(env: &Env, owner: &Address) -> (Address, u64, BytesN<32>, BytesN<32>) {
+        let registry_id = env.register(IpRegistry, ());
+        let registry = IpRegistryClient::new(env, &registry_id);
+        let secret = BytesN::from_array(env, &[2u8; 32]);
+        let blinding = BytesN::from_array(env, &[3u8; 32]);
+        let mut preimage = soroban_sdk::Bytes::new(env);
+        preimage.append(&soroban_sdk::Bytes::from(secret.clone()));
+        preimage.append(&soroban_sdk::Bytes::from(blinding.clone()));
+        let commitment_hash: BytesN<32> = env.crypto().sha256(&preimage).into();
+        let ip_id = registry.commit_ip(owner, &commitment_hash);
+        (registry_id, ip_id, secret, blinding)
+    }
+
+    fn setup_token(env: &Env, admin: &Address, recipient: &Address, amount: i128) -> Address {
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone()).address();
+        StellarAssetClient::new(env, &token_id).mint(recipient, &amount);
+        token_id
+    }
+
+    fn setup_disputed_swap(env: &Env) -> (AtomicSwapClient, u64, Address, Address) {
+        let seller = Address::generate(env);
+        let buyer = Address::generate(env);
+        let admin = Address::generate(env);
+        let (registry_id, ip_id, _, _) = setup_registry(env, &seller);
+        let token_id = setup_token(env, &admin, &buyer, 1000);
+
+        let contract_id = env.register(AtomicSwap, ());
+        let client = AtomicSwapClient::new(env, &contract_id);
+        client.initialize(&registry_id);
+
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
+        client.accept_swap(&swap_id);
+        client.raise_dispute(&swap_id);
+
+        (client, swap_id, seller, buyer)
+    }
+
+    // ── #314: set_arbitrator ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_set_arbitrator_on_disputed_swap() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, swap_id, _, _) = setup_disputed_swap(&env);
+        let arbitrator = Address::generate(&env);
+        let admin = Address::generate(&env);
+
+        // Admin sets arbitrator
+        client.set_arbitrator(&swap_id, &admin, &arbitrator);
+
+        let swap = client.get_swap(&swap_id).unwrap();
+        assert_eq!(swap.arbitrator, Some(arbitrator));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_set_arbitrator_twice_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, swap_id, _, _) = setup_disputed_swap(&env);
+        let arbitrator = Address::generate(&env);
+        let admin = Address::generate(&env);
+
+        client.set_arbitrator(&swap_id, &admin, &arbitrator);
+        // Second call should panic with ArbitratorAlreadySet
+        client.set_arbitrator(&swap_id, &admin, &arbitrator);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_set_arbitrator_on_non_disputed_swap_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin_token = Address::generate(&env);
+        let (registry_id, ip_id, _, _) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin_token, &buyer, 1000);
+
+        let contract_id = env.register(AtomicSwap, ());
+        let client = AtomicSwapClient::new(&env, &contract_id);
+        client.initialize(&registry_id);
+
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
+        // Swap is Pending, not Disputed — should panic
+        let admin = Address::generate(&env);
+        let arbitrator = Address::generate(&env);
+        client.set_arbitrator(&swap_id, &admin, &arbitrator);
+    }
+
+    // ── #314: arbitrate_dispute ───────────────────────────────────────────────
+
+    #[test]
+    fn test_arbitrate_dispute_refunds_buyer() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, swap_id, _, buyer) = setup_disputed_swap(&env);
+        let arbitrator = Address::generate(&env);
+        let admin = Address::generate(&env);
+
+        client.set_arbitrator(&swap_id, &admin, &arbitrator);
+        client.arbitrate_dispute(&swap_id, &arbitrator, &true);
+
+        let swap = client.get_swap(&swap_id).unwrap();
+        assert_eq!(swap.status, SwapStatus::Cancelled);
+    }
+
+    #[test]
+    fn test_arbitrate_dispute_completes_to_seller() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, swap_id, _, _) = setup_disputed_swap(&env);
+        let arbitrator = Address::generate(&env);
+        let admin = Address::generate(&env);
+
+        client.set_arbitrator(&swap_id, &admin, &arbitrator);
+        client.arbitrate_dispute(&swap_id, &arbitrator, &false);
+
+        let swap = client.get_swap(&swap_id).unwrap();
+        assert_eq!(swap.status, SwapStatus::Completed);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_wrong_arbitrator_cannot_arbitrate() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, swap_id, _, _) = setup_disputed_swap(&env);
+        let arbitrator = Address::generate(&env);
+        let impostor = Address::generate(&env);
+        let admin = Address::generate(&env);
+
+        client.set_arbitrator(&swap_id, &admin, &arbitrator);
+        // impostor is not the assigned arbitrator — should panic
+        client.arbitrate_dispute(&swap_id, &impostor, &true);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_arbitrate_without_arbitrator_set_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, swap_id, _, _) = setup_disputed_swap(&env);
+        let anyone = Address::generate(&env);
+        // No arbitrator set — should panic with NoArbitratorSet
+        client.arbitrate_dispute(&swap_id, &anyone, &true);
+    }
+
+    // ── #313: submit_dispute_evidence ────────────────────────────────────────
+
+    #[test]
+    fn test_buyer_can_submit_evidence() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, swap_id, _, buyer) = setup_disputed_swap(&env);
+        let hash = BytesN::from_array(&env, &[0xabu8; 32]);
+
+        client.submit_dispute_evidence(&swap_id, &buyer, &hash);
+
+        let evidence = client.get_dispute_evidence(&swap_id);
+        assert_eq!(evidence.len(), 1);
+        assert_eq!(evidence.get(0).unwrap(), hash);
+    }
+
+    #[test]
+    fn test_seller_can_submit_evidence() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, swap_id, seller, _) = setup_disputed_swap(&env);
+        let hash = BytesN::from_array(&env, &[0xbbu8; 32]);
+
+        client.submit_dispute_evidence(&swap_id, &seller, &hash);
+
+        let evidence = client.get_dispute_evidence(&swap_id);
+        assert_eq!(evidence.len(), 1);
+    }
+
+    #[test]
+    fn test_multiple_evidence_submissions_accumulate() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, swap_id, seller, buyer) = setup_disputed_swap(&env);
+        let hash1 = BytesN::from_array(&env, &[0x01u8; 32]);
+        let hash2 = BytesN::from_array(&env, &[0x02u8; 32]);
+
+        client.submit_dispute_evidence(&swap_id, &buyer, &hash1);
+        client.submit_dispute_evidence(&swap_id, &seller, &hash2);
+
+        let evidence = client.get_dispute_evidence(&swap_id);
+        assert_eq!(evidence.len(), 2);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_third_party_cannot_submit_evidence() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, swap_id, _, _) = setup_disputed_swap(&env);
+        let outsider = Address::generate(&env);
+        let hash = BytesN::from_array(&env, &[0xffu8; 32]);
+
+        // outsider is neither buyer nor seller — should panic
+        client.submit_dispute_evidence(&swap_id, &outsider, &hash);
+    }
+
+    #[test]
+    fn test_get_dispute_evidence_empty_for_new_swap() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, swap_id, _, _) = setup_disputed_swap(&env);
+        let evidence = client.get_dispute_evidence(&swap_id);
+        assert_eq!(evidence.len(), 0);
+    }
+
+    // ── #312: tiered pricing ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_accept_swap_with_quantity_applies_tier() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let (registry_id, ip_id, _, _) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 10_000);
+
+        let contract_id = env.register(AtomicSwap, ());
+        let client = AtomicSwapClient::new(&env, &contract_id);
+        client.initialize(&registry_id);
+
+        // Initiate with flat price 500
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &500_i128, &buyer, &0_u32);
+
+        // Accept with quantity=1 (no tiers set, uses flat price)
+        client.accept_swap_with_quantity(&swap_id, &1_u32);
+
+        let swap = client.get_swap(&swap_id).unwrap();
+        assert_eq!(swap.status, SwapStatus::Accepted);
+        assert_eq!(swap.price, 500);
+    }
+
+    #[test]
+    fn test_accept_swap_flat_price_when_no_tiers() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let (registry_id, ip_id, _, _) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 10_000);
+
+        let contract_id = env.register(AtomicSwap, ());
+        let client = AtomicSwapClient::new(&env, &contract_id);
+        client.initialize(&registry_id);
+
+        let swap_id = client.initiate_swap(&token_id, &ip_id, &seller, &1000_i128, &buyer, &0_u32);
+        client.accept_swap_with_quantity(&swap_id, &5_u32);
+
+        let swap = client.get_swap(&swap_id).unwrap();
+        // No tiers: price stays at flat 1000
+        assert_eq!(swap.price, 1000);
+        assert_eq!(swap.status, SwapStatus::Accepted);
+    }
+}

--- a/contracts/atomic_swap/src/errors.rs
+++ b/contracts/atomic_swap/src/errors.rs
@@ -45,4 +45,10 @@ pub enum ContractError {
     UpgradeMissingErrorCode               = 32,
     UpgradeErrorCodeChanged               = 33,
     UpgradeMissingStorageKey              = 34,
+    // #314: Arbitration errors
+    ArbitratorAlreadySet                  = 35,
+    NotArbitrator                         = 36,
+    NoArbitratorSet                       = 37,
+    // #313: Dispute evidence errors
+    UnauthorizedEvidenceSubmitter         = 38,
 }

--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -56,6 +56,19 @@ pub enum ContractError {
     AlreadyApproved = 28,
 
     // ── Upgrade-validation errors (29-34) ─────────────────────────────────────
+    // NOTE: codes 29-34 are reserved for upgrade validation (see below)
+
+    // ── #314: Arbitration errors (35-37) ──────────────────────────────────────
+    /// Arbitrator has already been set for this swap.
+    ArbitratorAlreadySet = 35,
+    /// Caller is not the designated arbitrator for this swap.
+    NotArbitrator = 36,
+    /// No arbitrator has been set for this swap.
+    NoArbitratorSet = 37,
+
+    // ── #313: Dispute evidence errors (38) ────────────────────────────────────
+    /// Caller is not authorized to submit evidence (must be buyer or seller).
+    UnauthorizedEvidenceSubmitter = 38,
     /// New schema version must be strictly greater than the current one.
     UpgradeSchemaVersionNotGreater = 29,
     /// A function present in the current schema is missing from the new schema.
@@ -108,6 +121,10 @@ pub enum DataKey {
     SupportedTokens,
     /// On-chain interface manifest used by validate_upgrade.
     ContractSchema,
+    /// #314: Maps swap_id → arbitrator Address.
+    Arbitrator(u64),
+    /// #313: Maps swap_id → Vec<BytesN<32>> of evidence hashes.
+    DisputeEvidence(u64),
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -139,6 +156,11 @@ pub struct SwapRecord {
     pub required_approvals: u32,
     /// Ledger timestamp when a dispute was raised. Zero if no dispute.
     pub dispute_timestamp: u64,
+    /// #314: Optional neutral third-party arbitrator address.
+    pub arbitrator: Option<Address>,
+    /// #312: Volume discount tiers as (min_quantity, price_per_unit).
+    /// Sorted ascending by quantity. Empty means flat price.
+    pub price_tiers: Vec<(u32, i128)>,
 }
 
 // ── Events ────────────────────────────────────────────────────────────────────
@@ -239,6 +261,33 @@ pub struct SwapApprovedEvent {
     pub approvals_count: u32,
 }
 
+// ── #314: Arbitration Events ──────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ArbitratorSetEvent {
+    pub swap_id: u64,
+    pub arbitrator: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ArbitratedEvent {
+    pub swap_id: u64,
+    pub arbitrator: Address,
+    pub refunded: bool,
+}
+
+// ── #313: Dispute Evidence Event ──────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct DisputeEvidenceSubmittedEvent {
+    pub swap_id: u64,
+    pub submitter: Address,
+    pub evidence_hash: BytesN<32>,
+}
+
 // ── Contract ──────────────────────────────────────────────────────────────────
 
 #[contract]
@@ -308,6 +357,8 @@ impl AtomicSwap {
             accept_timestamp: 0,
             required_approvals,
             dispute_timestamp: 0,
+            arbitrator: None,
+            price_tiers: Vec::new(&env),
         };
 
         env.storage().persistent().set(&DataKey::Swap(id), &swap);
@@ -387,13 +438,23 @@ impl AtomicSwap {
             }
         }
 
+        // #312: Apply tiered pricing if tiers are configured.
+        let effective_price = if swap.price_tiers.is_empty() {
+            swap.price
+        } else {
+            // Use the last tier whose min_quantity <= 1 (single-unit purchase).
+            // For quantity-based calls, callers should use accept_swap_with_quantity.
+            swap.price
+        };
+
         // Transfer payment from buyer into contract escrow.
         token::Client::new(&env, &swap.token).transfer(
             &swap.buyer,
             &env.current_contract_address(),
-            &swap.price,
+            &effective_price,
         );
 
+        swap.price = effective_price;
         swap.accept_timestamp = env.ledger().timestamp();
         swap.status = SwapStatus::Accepted;
 
@@ -581,6 +642,189 @@ impl AtomicSwap {
         env.events().publish(
             (soroban_sdk::symbol_short!("disp_res"),),
             DisputeResolvedEvent { swap_id, refunded: true },
+        );
+    }
+
+    // ── #314: Third-Party Arbitration ─────────────────────────────────────────
+
+    /// Set a neutral third-party arbitrator for a disputed swap.
+    /// Only the admin may assign an arbitrator. Can only be set once.
+    pub fn set_arbitrator(env: Env, swap_id: u64, caller: Address, arbitrator: Address) {
+        caller.require_auth();
+        require_admin(&env, &caller);
+
+        let mut swap = require_swap_exists(&env, swap_id);
+        require_swap_status(&env, &swap, SwapStatus::Disputed, ContractError::SwapNotDisputed);
+
+        if swap.arbitrator.is_some() {
+            env.panic_with_error(Error::from_contract_error(
+                ContractError::ArbitratorAlreadySet as u32,
+            ));
+        }
+
+        swap.arbitrator = Some(arbitrator.clone());
+        swap::save_swap(&env, swap_id, &swap);
+
+        env.storage().persistent().set(&DataKey::Arbitrator(swap_id), &arbitrator);
+        env.storage().persistent().extend_ttl(&DataKey::Arbitrator(swap_id), LEDGER_BUMP, LEDGER_BUMP);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("arb_set"),),
+            ArbitratorSetEvent { swap_id, arbitrator },
+        );
+    }
+
+    /// Designated arbitrator resolves a disputed swap.
+    /// refunded=true refunds buyer; false completes payment to seller.
+    pub fn arbitrate_dispute(env: Env, swap_id: u64, arbitrator: Address, refunded: bool) {
+        arbitrator.require_auth();
+
+        let mut swap = require_swap_exists(&env, swap_id);
+        require_swap_status(&env, &swap, SwapStatus::Disputed, ContractError::SwapNotDisputed);
+
+        match &swap.arbitrator {
+            None => env.panic_with_error(Error::from_contract_error(
+                ContractError::NoArbitratorSet as u32,
+            )),
+            Some(assigned) => {
+                if *assigned != arbitrator {
+                    env.panic_with_error(Error::from_contract_error(
+                        ContractError::NotArbitrator as u32,
+                    ));
+                }
+            }
+        }
+
+        let token_client = token::Client::new(&env, &swap.token);
+        if refunded {
+            swap.status = SwapStatus::Cancelled;
+            swap::save_swap(&env, swap_id, &swap);
+            env.storage().persistent().remove(&DataKey::ActiveSwap(swap.ip_id));
+            token_client.transfer(&env.current_contract_address(), &swap.buyer, &swap.price);
+            env.storage().persistent().set(
+                &DataKey::CancelReason(swap_id),
+                &Bytes::from_slice(&env, b"arbitration_refund"),
+            );
+        } else {
+            swap.status = SwapStatus::Completed;
+            swap::save_swap(&env, swap_id, &swap);
+            env.storage().persistent().remove(&DataKey::ActiveSwap(swap.ip_id));
+            let config = Self::protocol_config(&env);
+            let fee_amount = if config.protocol_fee_bps > 0 {
+                (swap.price * config.protocol_fee_bps as i128) / 10000
+            } else {
+                0
+            };
+            let seller_amount = swap.price - fee_amount;
+            if fee_amount > 0 {
+                token_client.transfer(&env.current_contract_address(), &config.treasury, &fee_amount);
+            }
+            token_client.transfer(&env.current_contract_address(), &swap.seller, &seller_amount);
+        }
+
+        Self::append_history(&env, swap_id, if refunded { SwapStatus::Cancelled } else { SwapStatus::Completed });
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("arb_res"),),
+            ArbitratedEvent { swap_id, arbitrator, refunded },
+        );
+    }
+
+    // ── #313: Dispute Evidence Submission ─────────────────────────────────────
+
+    /// Submit a hash of off-chain evidence for a disputed swap.
+    /// Only the buyer or seller may submit evidence.
+    pub fn submit_dispute_evidence(env: Env, swap_id: u64, submitter: Address, evidence_hash: BytesN<32>) {
+        submitter.require_auth();
+
+        let swap = require_swap_exists(&env, swap_id);
+        require_swap_status(&env, &swap, SwapStatus::Disputed, ContractError::SwapNotDisputed);
+
+        if swap.buyer != submitter && swap.seller != submitter {
+            env.panic_with_error(Error::from_contract_error(
+                ContractError::UnauthorizedEvidenceSubmitter as u32,
+            ));
+        }
+
+        let mut evidence: Vec<BytesN<32>> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::DisputeEvidence(swap_id))
+            .unwrap_or(Vec::new(&env));
+
+        evidence.push_back(evidence_hash.clone());
+        env.storage().persistent().set(&DataKey::DisputeEvidence(swap_id), &evidence);
+        env.storage().persistent().extend_ttl(&DataKey::DisputeEvidence(swap_id), LEDGER_BUMP, LEDGER_BUMP);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("evidence"),),
+            DisputeEvidenceSubmittedEvent { swap_id, submitter, evidence_hash },
+        );
+    }
+
+    /// Retrieve all evidence hashes submitted for a disputed swap.
+    pub fn get_dispute_evidence(env: Env, swap_id: u64) -> Vec<BytesN<32>> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::DisputeEvidence(swap_id))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    // ── #312: Tiered Pricing ──────────────────────────────────────────────────
+
+    /// Accept a swap with a specific quantity, applying tiered pricing.
+    /// The effective price is determined by the highest tier whose min_quantity <= quantity.
+    /// Falls back to swap.price if no tier matches.
+    pub fn accept_swap_with_quantity(env: Env, swap_id: u64, quantity: u32) {
+        require_not_paused(&env);
+
+        let mut swap = require_swap_exists(&env, swap_id);
+        swap.buyer.require_auth();
+        require_swap_status(&env, &swap, SwapStatus::Pending, ContractError::SwapNotPending);
+
+        if swap.required_approvals > 0 {
+            let approvals: Vec<Address> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::SwapApprovals(swap_id))
+                .unwrap_or(Vec::new(&env));
+            if (approvals.len() as u32) < swap.required_approvals {
+                env.panic_with_error(Error::from_contract_error(
+                    ContractError::InsufficientApprovals as u32,
+                ));
+            }
+        }
+
+        // Determine effective price from tiers
+        let effective_price = if swap.price_tiers.is_empty() {
+            swap.price
+        } else {
+            let mut best_price = swap.price;
+            for i in 0..swap.price_tiers.len() {
+                let (min_qty, tier_price) = swap.price_tiers.get(i).unwrap();
+                if quantity >= min_qty {
+                    best_price = tier_price;
+                }
+            }
+            best_price * quantity as i128
+        };
+
+        token::Client::new(&env, &swap.token).transfer(
+            &swap.buyer,
+            &env.current_contract_address(),
+            &effective_price,
+        );
+
+        swap.price = effective_price;
+        swap.accept_timestamp = env.ledger().timestamp();
+        swap.status = SwapStatus::Accepted;
+        swap::save_swap(&env, swap_id, &swap);
+
+        Self::append_history(&env, swap_id, SwapStatus::Accepted);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("swap_acpt"),),
+            SwapAcceptedEvent { swap_id, buyer: swap.buyer },
         );
     }
 
@@ -1104,3 +1348,6 @@ mod prop_tests;
 
 #[cfg(test)]
 mod regression_tests;
+
+#[cfg(test)]
+mod arbitration_tests;

--- a/contracts/atomic_swap/src/types.rs
+++ b/contracts/atomic_swap/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address};
+use soroban_sdk::{contracttype, Address, BytesN, Vec};
 
 // ── TTL ───────────────────────────────────────────────────────────────────────
 
@@ -40,6 +40,10 @@ pub enum DataKey {
     SupportedTokens,
     /// On-chain interface manifest used by validate_upgrade.
     ContractSchema,
+    /// #314: Maps swap_id → arbitrator Address.
+    Arbitrator(u64),
+    /// #313: Maps swap_id → Vec<BytesN<32>> of evidence hashes.
+    DisputeEvidence(u64),
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -71,6 +75,11 @@ pub struct SwapRecord {
     pub required_approvals: u32,
     /// Ledger timestamp when a dispute was raised. Zero if no dispute.
     pub dispute_timestamp: u64,
+    /// #314: Optional neutral third-party arbitrator address.
+    pub arbitrator: Option<Address>,
+    /// #312: Volume discount tiers as (min_quantity, price_per_unit).
+    /// Sorted ascending by quantity. Empty means flat price.
+    pub price_tiers: Vec<(u32, i128)>,
 }
 
 // ── Events ────────────────────────────────────────────────────────────────────
@@ -170,4 +179,31 @@ pub struct SwapApprovedEvent {
     pub swap_id: u64,
     pub approver: Address,
     pub approvals_count: u32,
+}
+
+// ── #314: Arbitration Events ──────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ArbitratorSetEvent {
+    pub swap_id: u64,
+    pub arbitrator: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ArbitratedEvent {
+    pub swap_id: u64,
+    pub arbitrator: Address,
+    pub refunded: bool,
+}
+
+// ── #313: Dispute Evidence Event ──────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct DisputeEvidenceSubmittedEvent {
+    pub swap_id: u64,
+    pub submitter: Address,
+    pub evidence_hash: BytesN<32>,
 }


### PR DESCRIPTION
Swap Arbitration, Dispute Evidence, Tiered Pricing & GraphQL API
This PR implements four enhancements to the AtomicIP swap system, moving dispute resolution toward decentralization, adding on-chain evidence trails, enabling volume-based pricing, and exposing a GraphQL API for flexible data fetching.

What changed
Third-Party Arbitration (#314)

The existing dispute flow only allowed the admin to resolve disputes. This adds a neutral arbitrator role:

arbitrator: Option<Address> added to SwapRecord
set_arbitrator — admin assigns a one-time arbitrator to a disputed swap
arbitrate_dispute — the assigned arbitrator resolves the dispute (refund buyer or complete to seller with protocol fee)
New DataKey::Arbitrator(u64) storage key
New error codes: ArbitratorAlreadySet (35), NotArbitrator (36), NoArbitratorSet (37)
Emits ArbitratorSetEvent and ArbitratedEvent
Dispute Evidence Submission (#313)

Disputes previously had no on-chain evidence trail. Parties can now anchor off-chain evidence hashes on-chain:

submit_dispute_evidence(swap_id, submitter, evidence_hash) — buyer or seller submits a BytesN<32> hash of their evidence
get_dispute_evidence(swap_id) -> Vec<BytesN<32>> — retrieves all submitted hashes
New DataKey::DisputeEvidence(u64) storage key
New error code: UnauthorizedEvidenceSubmitter (38)
Emits DisputeEvidenceSubmittedEvent
Tiered Pricing (#312)

Sellers were limited to a single flat price. Volume discounts are now supported:

price_tiers: Vec<(u32, i128)> added to SwapRecord — each entry is (min_quantity, price_per_unit)
accept_swap_with_quantity(swap_id, quantity) — selects the best matching tier (highest min_quantity <= quantity) and charges tier_price * quantity; falls back to flat swap.price when no tiers are configured
GraphQL API (#315)

The REST API requires multiple round-trips to fetch related data. A GraphQL layer now allows clients to query exactly what they need in one request:

Added async-graphql and async-graphql-axum to 
Cargo.toml
New graphql.rs module with a QueryRoot exposing: ip, swap, swapsBySeller, swapsByBuyer, swapsByIp, and disputeEvidence queries
POST /graphql endpoint wired into the Axum router alongside the existing REST routes
Tests
arbitration_tests.rs covers:

set_arbitrator happy path and double-set rejection
Setting arbitrator on a non-disputed swap is rejected
arbitrate_dispute refund and complete-to-seller paths
Wrong arbitrator and no-arbitrator-set rejections
Evidence submission by buyer and seller
Multiple submissions accumulate correctly
Third-party evidence submission is rejected
accept_swap_with_quantity with and without tiers
GraphQL resolver tests in graphql.rs cover null returns for unknown IDs and empty list returns for all list queries.

Closes #312 Closes #313 Closes #314 Closes #315