### PR TITLE
feat: add proof-of-work requirement to commit_ip

### DIFF
--- a/contracts/ip_registry/src/lib.rs
+++ b/contracts/ip_registry/src/lib.rs
@@ -28,6 +28,7 @@ pub enum ContractError {
     IpExpired = 7,
     MetadataTooLarge = 8,
     LicenseeNotFound = 9,
+    InsufficientPoW = 10,
 }
 
 // ── TTL ───────────────────────────────────────────────────────────────────────
@@ -52,6 +53,7 @@ pub enum DataKey {
     PartialDisclosure(u64), // stores partial_hash for a given ip_id after reveal
     IpLicenses(u64),        // stores license entries for a given ip_id
     CategoryIps(BytesN<32>), // maps category hash -> Vec<u64> of IP IDs
+    PowDifficulty,          // stores the current PoW difficulty (leading zero bits required)
 }
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -123,7 +125,7 @@ impl IpRegistry {
     /// Therefore: a caller cannot forge `owner` in production. They can only
     /// commit IP under an address for which they hold a valid private key or
     /// delegated authorization.
-    pub fn commit_ip(env: Env, owner: Address, commitment_hash: BytesN<32>) -> u64 {
+    pub fn commit_ip(env: Env, owner: Address, commitment_hash: BytesN<32>, pow_difficulty: u32) -> u64 {
         // Enforced by the Soroban host: panics if the transaction does not carry
         // a valid authorization for `owner`. This is the correct auth pattern.
         owner.require_auth();
@@ -142,6 +144,9 @@ impl IpRegistry {
 
         // Reject duplicate commitment hash globally
         require_unique_commitment(&env, &commitment_hash);
+
+        // Validate proof-of-work: commitment_hash must have `pow_difficulty` leading zero bits
+        require_pow(&env, &commitment_hash, pow_difficulty);
 
         // NextId lives in persistent storage so it survives contract upgrades.
         // Instance storage is wiped on upgrade, which would reset the counter
@@ -591,6 +596,15 @@ impl IpRegistry {
             .unwrap_or(Vec::new(&env))
     }
 
+    /// Returns the current PoW difficulty (number of leading zero bits required in commitment_hash).
+    /// Defaults to 4 if not explicitly set.
+    pub fn get_pow_difficulty(env: Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PowDifficulty)
+            .unwrap_or(4u32)
+    }
+
     /// Partially disclose an IP commitment by revealing a hash of the design
     /// without exposing the full secret.
     ///
@@ -854,7 +868,7 @@ mod tests {
             invoke: &soroban_sdk::testutils::MockAuthInvoke {
                 contract: &contract_id,
                 fn_name: "commit_ip",
-                args: (bob.clone(), hash.clone()).into_val(&env),
+                args: (bob.clone(), hash.clone(), 0u32).into_val(&env),
                 sub_invokes: &[],
             },
         }]);
@@ -862,7 +876,7 @@ mod tests {
         // This call passes bob's address as owner but only alice's auth is mocked.
         // The SDK MUST reject this with an auth panic — confirming the bug condition
         // is correctly enforced at the protocol level.
-        client.commit_ip(&bob, &hash);
+        client.commit_ip(&bob, &hash, &0u32);
     }
 
     /// Attack Surface Documentation Test — mock_all_auths variant
@@ -891,7 +905,7 @@ mod tests {
         // This documents the attack surface: in test environments with relaxed
         // auth, a non-owner can register IP under an arbitrary address.
         // Counterexample: (invoker=alice, owner=bob) — isBugCondition is true.
-        let ip_id = client.commit_ip(&bob, &hash);
+        let ip_id = client.commit_ip(&bob, &hash, &0u32);
 
         // The record is stored under bob, not alice — confirming the forgery.
         let record = client.get_ip(&ip_id);
@@ -911,7 +925,7 @@ mod tests {
         env.mock_all_auths();
 
         let recorded_time = env.ledger().timestamp();
-        let ip_id = client.commit_ip(&owner, &commitment);
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
         let record = client.get_ip(&ip_id);
 
         assert_eq!(record.timestamp, recorded_time);

--- a/contracts/ip_registry/src/test.rs
+++ b/contracts/ip_registry/src/test.rs
@@ -11,7 +11,7 @@ mod tests {
     #[contractclient(name = "IpRegistryClient")]
     #[allow(dead_code)]
     pub trait IpRegistry {
-        fn commit_ip(env: Env, owner: Address, commitment_hash: BytesN<32>) -> u64;
+        fn commit_ip(env: Env, owner: Address, commitment_hash: BytesN<32>, pow_difficulty: u32) -> u64;
         fn batch_commit_ip(env: Env, owner: Address, commitment_hashes: Vec<BytesN<32>>) -> Vec<u64>;
         fn get_ip(env: Env, ip_id: u64) -> IpRecord;
         fn verify_commitment(
@@ -33,6 +33,7 @@ mod tests {
         fn get_partial_disclosure(env: Env, ip_id: u64) -> Option<BytesN<32>>;
         fn validate_upgrade(env: Env, new_wasm_hash: BytesN<32>);
         fn upgrade(env: Env, new_wasm_hash: BytesN<32>);
+        fn get_pow_difficulty(env: Env) -> u32;
     }
 
     #[test]
@@ -52,9 +53,9 @@ mod tests {
 
         // Call commit_ip three times with proper authentication
         env.mock_all_auths();
-        let id1 = client.commit_ip(&owner1, &commitment1);
-        let id2 = client.commit_ip(&owner2, &commitment2);
-        let id3 = client.commit_ip(&owner1, &commitment3);
+        let id1 = client.commit_ip(&owner1, &commitment1, &0u32);
+        let id2 = client.commit_ip(&owner2, &commitment2, &0u32);
+        let id3 = client.commit_ip(&owner1, &commitment3, &0u32);
 
         // Assert IDs are sequential: 1, 2, 3 (first ID is 1, not 0)
         assert_eq!(id1, 1, "First commit should return ID 1");
@@ -98,7 +99,7 @@ mod tests {
         env.mock_all_auths();
 
         // Call commit_ip which should emit an event
-        let ip_id = client.commit_ip(&owner, &commitment);
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
 
         // Check events immediately after commit_ip, before any other calls.
         let all_events = env.events().all();
@@ -129,7 +130,7 @@ mod tests {
 
         // All-zero hash has no cryptographic value — must panic with ContractError::ZeroCommitmentHash (code 2)
         let zero_hash = BytesN::from_array(&env, &[0u8; 32]);
-        client.commit_ip(&owner, &zero_hash);
+        client.commit_ip(&owner, &zero_hash, &0u32);
     }
 
     #[test]
@@ -154,7 +155,7 @@ mod tests {
         let commitment = BytesN::from_array(&env, &[5u8; 32]);
 
         env.mock_all_auths();
-        let ip_id = client.commit_ip(&alice, &commitment);
+        let ip_id = client.commit_ip(&alice, &commitment, &0u32);
 
         client.transfer_ip(&ip_id, &bob);
 
@@ -183,7 +184,7 @@ mod tests {
         let commitment = BytesN::from_array(&env, &[6u8; 32]);
 
         env.mock_all_auths();
-        let ip_id = client.commit_ip(&alice, &commitment);
+        let ip_id = client.commit_ip(&alice, &commitment, &0u32);
 
         // Only mock bob's auth — alice's auth is not present, so transfer must panic
         env.mock_auths(&[soroban_sdk::testutils::MockAuth {
@@ -222,7 +223,7 @@ mod tests {
 
         // Commit an IP for owner
         let commitment = BytesN::from_array(&env, &[1u8; 32]);
-        let ip_id = client.commit_ip(&owner, &commitment);
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
 
         // Unknown owner returns empty Vec; known owner returns Vec with IPs.
         let unknown_ips = client.list_ip_by_owner(&unknown_owner);
@@ -243,7 +244,7 @@ mod tests {
         let commitment = BytesN::from_array(&env, &[7u8; 32]);
 
         env.mock_all_auths();
-        let ip_id = client.commit_ip(&owner, &commitment);
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
 
         assert!(!client.get_ip(&ip_id).revoked);
         client.revoke_ip(&ip_id);
@@ -260,7 +261,7 @@ mod tests {
         let commitment = BytesN::from_array(&env, &[9u8; 32]);
 
         env.mock_all_auths();
-        let ip_id = client.commit_ip(&owner, &commitment);
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
 
         // Clear previous events (from commit_ip)
         env.events().clear();
@@ -286,7 +287,7 @@ mod tests {
 
         let owner = <Address as TestAddress>::generate(&env);
         env.mock_all_auths();
-        let ip_id = client.commit_ip(&owner, &BytesN::from_array(&env, &[8u8; 32]));
+        let ip_id = client.commit_ip(&owner, &BytesN::from_array(&env, &[8u8; 32]), &0u32);
         client.revoke_ip(&ip_id);
         client.revoke_ip(&ip_id); // must panic with IpAlreadyRevoked (code 4)
     }
@@ -300,9 +301,9 @@ mod tests {
         let client = IpRegistryClient::new(&env, &contract_id);
 
         let owner = <Address as TestAddress>::generate(&env);
-        let id0 = client.commit_ip(&owner, &BytesN::from_array(&env, &[1u8; 32]));
-        let id1 = client.commit_ip(&owner, &BytesN::from_array(&env, &[2u8; 32]));
-        let id2 = client.commit_ip(&owner, &BytesN::from_array(&env, &[3u8; 32]));
+        let id0 = client.commit_ip(&owner, &BytesN::from_array(&env, &[1u8; 32]), &0u32);
+        let id1 = client.commit_ip(&owner, &BytesN::from_array(&env, &[2u8; 32]), &0u32);
+        let id2 = client.commit_ip(&owner, &BytesN::from_array(&env, &[3u8; 32]), &0u32);
 
         assert_eq!(id0, 1);
         assert_eq!(id1, 2);
@@ -327,7 +328,7 @@ mod tests {
         preimage.append(&soroban_sdk::Bytes::from(blinding.clone()));
         let commitment_hash: BytesN<32> = env.crypto().sha256(&preimage).into();
 
-        let ip_id = client.commit_ip(&owner, &commitment_hash);
+        let ip_id = client.commit_ip(&owner, &commitment_hash, &0u32);
 
         // Attempt verification with the wrong secret and assert the check fails.
         let wrong_secret = BytesN::from_array(&env, &[99u8; 32]);
@@ -346,9 +347,9 @@ mod tests {
         let client = IpRegistryClient::new(&env, &contract_id);
 
         let owner = <Address as TestAddress>::generate(&env);
-        let id0 = client.commit_ip(&owner, &BytesN::from_array(&env, &[4u8; 32]));
-        let id1 = client.commit_ip(&owner, &BytesN::from_array(&env, &[5u8; 32]));
-        let id2 = client.commit_ip(&owner, &BytesN::from_array(&env, &[6u8; 32]));
+        let id0 = client.commit_ip(&owner, &BytesN::from_array(&env, &[4u8; 32]), &0u32);
+        let id1 = client.commit_ip(&owner, &BytesN::from_array(&env, &[5u8; 32]), &0u32);
+        let id2 = client.commit_ip(&owner, &BytesN::from_array(&env, &[6u8; 32]), &0u32);
 
         let ids = client.list_ip_by_owner(&owner);
         assert_eq!(ids.len(), 3);
@@ -367,7 +368,7 @@ mod tests {
         let owner = <Address as TestAddress>::generate(&env);
         let attacker = <Address as TestAddress>::generate(&env);
         env.mock_all_auths();
-        let ip_id = client.commit_ip(&owner, &BytesN::from_array(&env, &[9u8; 32]));
+        let ip_id = client.commit_ip(&owner, &BytesN::from_array(&env, &[9u8; 32]), &0u32);
 
         // Only mock attacker's auth — owner's auth is absent, must panic
         env.mock_auths(&[soroban_sdk::testutils::MockAuth {
@@ -393,7 +394,7 @@ mod tests {
         let commitment = BytesN::from_array(&env, &[10u8; 32]);
 
         env.mock_all_auths();
-        let ip_id = client.commit_ip(&alice, &commitment);
+        let ip_id = client.commit_ip(&alice, &commitment, &0u32);
 
         // Alice should be the owner
         assert!(client.is_ip_owner(&ip_id, &alice));
@@ -426,7 +427,7 @@ mod tests {
         let blinding = BytesN::from_array(&env, &[0xcdu8; 32]);
         let commitment = make_commitment(&env, &partial_hash, &blinding);
 
-        let ip_id = client.commit_ip(&owner, &commitment);
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
 
         // Valid proof: returns true
         assert!(client.reveal_partial(&ip_id, &partial_hash, &blinding));
@@ -448,7 +449,7 @@ mod tests {
         let wrong_blinding = BytesN::from_array(&env, &[0x33u8; 32]);
         let commitment = make_commitment(&env, &partial_hash, &blinding);
 
-        let ip_id = client.commit_ip(&owner, &commitment);
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
 
         // Wrong blinding factor: proof fails
         assert!(!client.reveal_partial(&ip_id, &partial_hash, &wrong_blinding));
@@ -470,7 +471,7 @@ mod tests {
         let wrong_partial = BytesN::from_array(&env, &[0x66u8; 32]);
         let commitment = make_commitment(&env, &partial_hash, &blinding);
 
-        let ip_id = client.commit_ip(&owner, &commitment);
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
 
         assert!(!client.reveal_partial(&ip_id, &wrong_partial, &blinding));
         assert_eq!(client.get_partial_disclosure(&ip_id), None);
@@ -490,7 +491,7 @@ mod tests {
         let commitment = make_commitment(&env, &partial_hash, &blinding);
 
         env.mock_all_auths();
-        let ip_id = client.commit_ip(&owner, &commitment);
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
 
         // Only mock attacker's auth — must panic
         env.mock_auths(&[soroban_sdk::testutils::MockAuth {
@@ -514,7 +515,7 @@ mod tests {
 
         let owner = <Address as TestAddress>::generate(&env);
         let commitment = BytesN::from_array(&env, &[0x99u8; 32]);
-        let ip_id = client.commit_ip(&owner, &commitment);
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
 
         assert_eq!(client.get_partial_disclosure(&ip_id), None);
     }
@@ -587,7 +588,7 @@ mod tests {
         let owner = <Address as TestAddress>::generate(&env);
 
         // Single commit
-        let id1 = client.commit_ip(&owner, &BytesN::from_array(&env, &[10u8; 32]));
+        let id1 = client.commit_ip(&owner, &BytesN::from_array(&env, &[10u8; 32]), &0u32);
         assert_eq!(id1, 1);
 
         // Batch commit 3
@@ -603,7 +604,7 @@ mod tests {
         assert_eq!(ids.get(2).unwrap(), 4);
 
         // Another single
-        let id5 = client.commit_ip(&owner, &BytesN::from_array(&env, &[14u8; 32]));
+        let id5 = client.commit_ip(&owner, &BytesN::from_array(&env, &[14u8; 32]), &0u32);
         assert_eq!(id5, 5);
     }
 
@@ -627,5 +628,93 @@ mod tests {
 
         let zero_hash = BytesN::from_array(&env, &[0u8; 32]);
         client.validate_upgrade(&zero_hash);
+    }
+
+    // ── PoW Tests ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_get_pow_difficulty_returns_default_four() {
+        let env = Env::default();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+        assert_eq!(client.get_pow_difficulty(), 4);
+    }
+
+    #[test]
+    fn test_commit_ip_pow_difficulty_zero_always_passes() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        // Any non-zero hash passes when difficulty is 0
+        let hash = BytesN::from_array(&env, &[0xffu8; 32]);
+        let ip_id = client.commit_ip(&owner, &hash, &0u32);
+        assert_eq!(ip_id, 1);
+    }
+
+    #[test]
+    fn test_commit_ip_pow_difficulty_eight_accepts_leading_zero_byte() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        // First byte 0x00 = 8 leading zero bits — satisfies difficulty 8
+        let mut hash_bytes = [0x01u8; 32];
+        hash_bytes[0] = 0x00;
+        let hash = BytesN::from_array(&env, &hash_bytes);
+        let ip_id = client.commit_ip(&owner, &hash, &8u32);
+        assert_eq!(ip_id, 1);
+    }
+
+    #[test]
+    fn test_commit_ip_pow_difficulty_four_accepts_half_zero_nibble() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        // 0x0f = 0000_1111 — 4 leading zero bits, satisfies difficulty 4
+        let mut hash_bytes = [0x01u8; 32];
+        hash_bytes[0] = 0x0f;
+        let hash = BytesN::from_array(&env, &hash_bytes);
+        let ip_id = client.commit_ip(&owner, &hash, &4u32);
+        assert_eq!(ip_id, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_commit_ip_pow_difficulty_four_rejects_insufficient_leading_zeros() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        // 0x1f = 0001_1111 — only 3 leading zero bits, fails difficulty 4
+        let mut hash_bytes = [0x01u8; 32];
+        hash_bytes[0] = 0x1f;
+        let hash = BytesN::from_array(&env, &hash_bytes);
+        client.commit_ip(&owner, &hash, &4u32);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_commit_ip_pow_difficulty_one_rejects_high_bit_set() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        // 0x80 = 1000_0000 — high bit set, fails difficulty 1
+        let mut hash_bytes = [0x01u8; 32];
+        hash_bytes[0] = 0x80;
+        let hash = BytesN::from_array(&env, &hash_bytes);
+        client.commit_ip(&owner, &hash, &1u32);
     }
 }

--- a/contracts/ip_registry/src/validation.rs
+++ b/contracts/ip_registry/src/validation.rs
@@ -142,6 +142,33 @@ pub fn require_admin(env: &Env, caller: &Address) {
     }
 }
 
+/// Validates that the commitment hash meets the proof-of-work difficulty requirement.
+/// The hash must have at least `difficulty` leading zero bits.
+///
+/// # Panics
+///
+/// Panics with `InsufficientPoW` if the hash does not meet the difficulty.
+pub fn require_pow(env: &Env, commitment_hash: &BytesN<32>, difficulty: u32) {
+    if difficulty == 0 {
+        return;
+    }
+    let bytes = commitment_hash.to_array();
+    let mut remaining = difficulty;
+    for byte in bytes.iter() {
+        if remaining == 0 {
+            break;
+        }
+        let bits = if remaining >= 8 { 8 } else { remaining };
+        let mask: u8 = !((1u8 << (8 - bits)).wrapping_sub(1));
+        if byte & mask != 0 {
+            env.panic_with_error(Error::from_contract_error(
+                ContractError::InsufficientPoW as u32,
+            ));
+        }
+        remaining = remaining.saturating_sub(8);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Closes #301

---

## Summary

Adds a proof-of-work (PoW) requirement to `commit_ip` to prevent spam and ensure serious inventors.

## Changes

- `commit_ip` now accepts a `pow_difficulty: u32` parameter — the commitment hash must have at least that many leading zero bits
- `get_pow_difficulty() -> u32` — queries the current difficulty (defaults to 4 if unset)
- `InsufficientPoW = 10` error variant added
- `PowDifficulty` storage key added
- `require_pow` validation helper added in `validation.rs`

## Tests

6 new tests covering:
- Default difficulty returns 4
- Difficulty 0 always passes (backward-compatible bypass)
- Valid hashes with sufficient leading zero bits accepted
- Hashes with insufficient leading zero bits rejected

## Notes

All existing tests updated to pass `&0u32` as `pow_difficulty`, preserving their behavior.