### PR TITLE
feat: add suggested_price to ip_registry

### DIFF
--- a/contracts/ip_registry/src/lib.rs
+++ b/contracts/ip_registry/src/lib.rs
@@ -52,6 +52,7 @@ pub enum DataKey {
     PartialDisclosure(u64), // stores partial_hash for a given ip_id after reveal
     IpLicenses(u64),        // stores license entries for a given ip_id
     CategoryIps(BytesN<32>), // maps category hash -> Vec<u64> of IP IDs
+    SuggestedPrice(u64),    // optional asking price set by the IP owner
 }
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -771,6 +772,24 @@ impl IpRegistry {
             .persistent()
             .get(&DataKey::IpLicenses(ip_id))
             .unwrap_or(Vec::new(&env))
+    }
+
+    /// Set or update the suggested price for an IP. Owner-only. Pass 0 to clear.
+    pub fn set_ip_suggested_price(env: Env, ip_id: u64, price: i128) {
+        let record = require_ip_exists(&env, ip_id);
+        record.owner.require_auth();
+        if price == 0 {
+            env.storage().persistent().remove(&DataKey::SuggestedPrice(ip_id));
+        } else {
+            env.storage().persistent().set(&DataKey::SuggestedPrice(ip_id), &price);
+            env.storage().persistent().extend_ttl(&DataKey::SuggestedPrice(ip_id), LEDGER_BUMP, LEDGER_BUMP);
+        }
+    }
+
+    /// Get the suggested price for an IP. Returns None if no price has been set.
+    pub fn get_ip_suggested_price(env: Env, ip_id: u64) -> Option<i128> {
+        require_ip_exists(&env, ip_id);
+        env.storage().persistent().get(&DataKey::SuggestedPrice(ip_id))
     }
 
     /// Add a co-owner to an IP. Owner-only.

--- a/contracts/ip_registry/src/test.rs
+++ b/contracts/ip_registry/src/test.rs
@@ -33,6 +33,8 @@ mod tests {
         fn get_partial_disclosure(env: Env, ip_id: u64) -> Option<BytesN<32>>;
         fn validate_upgrade(env: Env, new_wasm_hash: BytesN<32>);
         fn upgrade(env: Env, new_wasm_hash: BytesN<32>);
+        fn set_ip_suggested_price(env: Env, ip_id: u64, price: i128);
+        fn get_ip_suggested_price(env: Env, ip_id: u64) -> Option<i128>;
     }
 
     #[test]
@@ -627,5 +629,76 @@ mod tests {
 
         let zero_hash = BytesN::from_array(&env, &[0u8; 32]);
         client.validate_upgrade(&zero_hash);
+    }
+
+    // ── Suggested Price Tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_get_ip_suggested_price_returns_none_when_unset() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let ip_id = client.commit_ip(&owner, &BytesN::from_array(&env, &[1u8; 32]));
+
+        assert_eq!(client.get_ip_suggested_price(&ip_id), None);
+    }
+
+    #[test]
+    fn test_set_and_get_ip_suggested_price() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let ip_id = client.commit_ip(&owner, &BytesN::from_array(&env, &[2u8; 32]));
+
+        client.set_ip_suggested_price(&ip_id, &5000i128);
+        assert_eq!(client.get_ip_suggested_price(&ip_id), Some(5000i128));
+    }
+
+    #[test]
+    fn test_set_ip_suggested_price_zero_clears_price() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let ip_id = client.commit_ip(&owner, &BytesN::from_array(&env, &[3u8; 32]));
+
+        client.set_ip_suggested_price(&ip_id, &9999i128);
+        assert_eq!(client.get_ip_suggested_price(&ip_id), Some(9999i128));
+
+        client.set_ip_suggested_price(&ip_id, &0i128);
+        assert_eq!(client.get_ip_suggested_price(&ip_id), None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_set_ip_suggested_price_requires_owner_auth() {
+        let env = Env::default();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let attacker = <Address as TestAddress>::generate(&env);
+
+        env.mock_all_auths();
+        let ip_id = client.commit_ip(&owner, &BytesN::from_array(&env, &[4u8; 32]));
+
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &attacker,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "set_ip_suggested_price",
+                args: (ip_id, 1000i128).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        client.set_ip_suggested_price(&ip_id, &1000i128);
     }
 }


### PR DESCRIPTION
Closes #300

---

## Summary

Inventors can now suggest a valuation for their IP so buyers have a reference price.

## Design

Stored as a separate `SuggestedPrice(u64) -> i128` key rather than a field on `IpRecord`. This avoids breaking the existing struct layout and requires no data migration.

## Changes

- `SuggestedPrice(u64)` DataKey added
- `set_ip_suggested_price(env, ip_id, price)` — owner-only; passing `0` removes the price
- `get_ip_suggested_price(env, ip_id) -> Option<i128>` — returns `None` if unset

## Tests

- Returns `None` when no price set
- Set and get round-trips correctly
- Passing `0` clears the price (returns `None`)
- Non-owner cannot set price (auth panic)