### PR TITLE
Feature/renew ip expiry

### DIFF
--- a/contracts/ip_registry/src/lib.rs
+++ b/contracts/ip_registry/src/lib.rs
@@ -777,6 +777,29 @@ impl IpRegistry {
         env.storage().persistent().extend_ttl(&DataKey::IpRecord(ip_id), LEDGER_BUMP, LEDGER_BUMP);
     }
 
+    /// Renew an IP's expiry to extend its protection period. Owner-only.
+    ///
+    /// `new_expiry` must be strictly greater than the current expiry timestamp.
+    /// Emits an event with (ip_id, old_expiry, new_expiry).
+    pub fn renew_ip(env: Env, ip_id: u64, new_expiry: u64) {
+        let mut record = require_ip_exists(&env, ip_id);
+        record.owner.require_auth();
+
+        let old_expiry = record.expiry_timestamp;
+        if new_expiry <= old_expiry {
+            env.panic_with_error(Error::from_contract_error(ContractError::InvalidExpiry as u32));
+        }
+
+        record.expiry_timestamp = new_expiry;
+        env.storage().persistent().set(&DataKey::IpRecord(ip_id), &record);
+        env.storage().persistent().extend_ttl(&DataKey::IpRecord(ip_id), LEDGER_BUMP, LEDGER_BUMP);
+
+        env.events().publish(
+            (symbol_short!("renew_ip"), record.owner),
+            (ip_id, old_expiry, new_expiry),
+        );
+    }
+
     /// Set or update metadata for an IP (max 1 KB). Owner-only.
     pub fn set_ip_metadata(env: Env, ip_id: u64, metadata: Bytes) {
         if metadata.len() > MAX_METADATA_BYTES {

--- a/contracts/ip_registry/src/lib.rs
+++ b/contracts/ip_registry/src/lib.rs
@@ -84,6 +84,7 @@ pub enum DataKey {
     IpCommitmentChecksum,   // Issue #346: stores hash of all commitments for rollback protection
     IpAccessGrants(u64),    // Issue #344: stores Vec of (grantee, access_level) for tiered access
     NotarySignature(u64),   // Issue #345: stores notary signature for timestamp notarization
+    IpAttestations(u64),    // stores Vec<Attestation> for third-party attestations
 }
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -103,6 +104,14 @@ pub struct IpDispute {
     pub evidence_hash: BytesN<32>,
     pub timestamp: u64,
     pub resolved: bool,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Attestation {
+    pub attestor: Address,
+    pub attestation_data: Bytes,
+    pub timestamp: u64,
 }
 
 // ── Contract ─────────────────────────────────────────────────────────────────
@@ -1269,6 +1278,53 @@ impl IpRegistry {
     pub fn get_ip_notary_signature(env: Env, ip_id: u64) -> Option<Bytes> {
         let record = require_ip_exists(&env, ip_id);
         record.notary_signature.clone()
+    }
+
+    // ── Third-Party Attestations ───────────────────────────────────────────────
+
+    /// Allow any third party (notary, university, etc.) to attest to an IP's authenticity.
+    ///
+    /// Anyone can call this — no owner restriction. The attestor must authorize the call.
+    pub fn attest_ip(env: Env, ip_id: u64, attestor: Address, attestation_data: Bytes) {
+        // Verify the IP exists
+        require_ip_exists(&env, ip_id);
+
+        // Attestor must authorize their own attestation
+        attestor.require_auth();
+
+        let attestation = Attestation {
+            attestor: attestor.clone(),
+            attestation_data,
+            timestamp: env.ledger().timestamp(),
+        };
+
+        let mut attestations: Vec<Attestation> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::IpAttestations(ip_id))
+            .unwrap_or(Vec::new(&env));
+        attestations.push_back(attestation);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::IpAttestations(ip_id), &attestations);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::IpAttestations(ip_id), LEDGER_BUMP, LEDGER_BUMP);
+
+        env.events().publish(
+            (symbol_short!("attest"), attestor),
+            (ip_id, env.ledger().timestamp()),
+        );
+    }
+
+    /// Retrieve all attestations for a given IP.
+    pub fn get_ip_attestations(env: Env, ip_id: u64) -> Vec<Attestation> {
+        require_ip_exists(&env, ip_id);
+        env.storage()
+            .persistent()
+            .get(&DataKey::IpAttestations(ip_id))
+            .unwrap_or(Vec::new(&env))
     }
 
     // ── Issue #346: Commitment Rollback Protection ─────────────────────────────

--- a/contracts/ip_registry/src/test.rs
+++ b/contracts/ip_registry/src/test.rs
@@ -43,6 +43,8 @@ mod tests {
         fn revoke_delegation(env: Env, owner: Address, delegate_address: Address);
         fn is_delegate(env: Env, owner: Address, delegate_address: Address) -> bool;
         fn commit_ip_delegated(env: Env, owner: Address, commitment_hash: BytesN<32>, pow_difficulty: u32) -> u64;
+        fn attest_ip(env: Env, ip_id: u64, attestor: Address, attestation_data: soroban_sdk::Bytes);
+        fn get_ip_attestations(env: Env, ip_id: u64) -> Vec<crate::Attestation>;
     }
 
     #[test]
@@ -941,5 +943,79 @@ mod tests {
         let record = client.get_ip(&ip_id);
         assert_eq!(record.owner, owner);
         assert_eq!(record.commitment_hash, hash);
+    }
+
+    // ── Tests for Third-Party Attestations ──
+
+    #[test]
+    fn test_attest_ip_by_third_party() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let notary = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[10u8; 32]);
+        let attestation_data = soroban_sdk::Bytes::from_array(&env, &[0xABu8; 32]);
+
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
+        client.attest_ip(&ip_id, &notary, &attestation_data);
+
+        let attestations = client.get_ip_attestations(&ip_id);
+        assert_eq!(attestations.len(), 1);
+        let att = attestations.get(0).unwrap();
+        assert_eq!(att.attestor, notary);
+        assert_eq!(att.attestation_data, attestation_data);
+    }
+
+    #[test]
+    fn test_multiple_attestors() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let notary = <Address as TestAddress>::generate(&env);
+        let university = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[11u8; 32]);
+
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
+        client.attest_ip(&ip_id, &notary, &soroban_sdk::Bytes::from_array(&env, &[1u8; 32]));
+        client.attest_ip(&ip_id, &university, &soroban_sdk::Bytes::from_array(&env, &[2u8; 32]));
+
+        let attestations = client.get_ip_attestations(&ip_id);
+        assert_eq!(attestations.len(), 2);
+        assert_eq!(attestations.get(0).unwrap().attestor, notary);
+        assert_eq!(attestations.get(1).unwrap().attestor, university);
+    }
+
+    #[test]
+    fn test_get_ip_attestations_empty() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[12u8; 32]);
+
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
+        let attestations = client.get_ip_attestations(&ip_id);
+        assert_eq!(attestations.len(), 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_attest_ip_nonexistent() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let attestor = <Address as TestAddress>::generate(&env);
+        // IP ID 999 does not exist — should panic
+        client.attest_ip(&999u64, &attestor, &soroban_sdk::Bytes::from_array(&env, &[1u8; 32]));
     }
 }

--- a/contracts/ip_registry/src/test.rs
+++ b/contracts/ip_registry/src/test.rs
@@ -45,6 +45,8 @@ mod tests {
         fn commit_ip_delegated(env: Env, owner: Address, commitment_hash: BytesN<32>, pow_difficulty: u32) -> u64;
         fn attest_ip(env: Env, ip_id: u64, attestor: Address, attestation_data: soroban_sdk::Bytes);
         fn get_ip_attestations(env: Env, ip_id: u64) -> Vec<crate::Attestation>;
+        fn set_ip_expiry(env: Env, ip_id: u64, expiry_timestamp: u64);
+        fn renew_ip(env: Env, ip_id: u64, new_expiry: u64);
     }
 
     #[test]
@@ -1017,5 +1019,111 @@ mod tests {
         let attestor = <Address as TestAddress>::generate(&env);
         // IP ID 999 does not exist — should panic
         client.attest_ip(&999u64, &attestor, &soroban_sdk::Bytes::from_array(&env, &[1u8; 32]));
+    }
+
+    // ── Tests for renew_ip ──
+
+    #[test]
+    fn test_renew_ip_success() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[20u8; 32]);
+
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
+        client.set_ip_expiry(&ip_id, &1000u64);
+        client.renew_ip(&ip_id, &2000u64);
+
+        let record = client.get_ip(&ip_id);
+        assert_eq!(record.expiry_timestamp, 2000u64);
+    }
+
+    #[test]
+    fn test_renew_ip_emits_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[21u8; 32]);
+
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
+        client.set_ip_expiry(&ip_id, &500u64);
+
+        let events_before = env.events().all().len();
+        client.renew_ip(&ip_id, &1500u64);
+
+        let all_events = env.events().all();
+        assert!(all_events.len() > events_before);
+        // Last event should be the renew event
+        let renew_event = all_events.get(all_events.len() - 1).unwrap();
+        let data: (u64, u64, u64) = soroban_sdk::TryFromVal::try_from_val(&env, &renew_event.2).unwrap();
+        assert_eq!(data.0, ip_id);
+        assert_eq!(data.1, 500u64);  // old_expiry
+        assert_eq!(data.2, 1500u64); // new_expiry
+    }
+
+    #[test]
+    #[should_panic(expected = "InvalidExpiry")]
+    fn test_renew_ip_same_expiry_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[22u8; 32]);
+
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
+        client.set_ip_expiry(&ip_id, &1000u64);
+        client.renew_ip(&ip_id, &1000u64); // same expiry — must panic
+    }
+
+    #[test]
+    #[should_panic(expected = "InvalidExpiry")]
+    fn test_renew_ip_lower_expiry_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[23u8; 32]);
+
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
+        client.set_ip_expiry(&ip_id, &1000u64);
+        client.renew_ip(&ip_id, &500u64); // lower expiry — must panic
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_renew_ip_non_owner_panics() {
+        let env = Env::default();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let other = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[24u8; 32]);
+
+        env.mock_all_auths();
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
+        client.set_ip_expiry(&ip_id, &1000u64);
+
+        // Only mock other's auth — owner's auth not present for renew_ip
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &other,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "renew_ip",
+                args: (ip_id, 2000u64).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        client.renew_ip(&ip_id, &2000u64);
     }
 }


### PR DESCRIPTION
closes #303 
lib.rs — renew_ip inserted right after set_ip_expiry:
- Owner-only via record.owner.require_auth()
- Reads old_expiry = record.expiry_timestamp, panics with InvalidExpiry if new_expiry <= old_expiry
- Saves updated record, emits ("renew_ip", owner) → (ip_id, old_expiry, new_expiry)

test.rs — added set_ip_expiry and renew_ip to the client trait, plus 5 tests:
- test_renew_ip_success — happy path, expiry updated
- test_renew_ip_emits_event — verifies event payload (ip_id, old_expiry, new_expiry)
- test_renew_ip_same_expiry_panics — InvalidExpiry on equal value
- test_renew_ip_lower_expiry_panics — InvalidExpiry on lower value
- test_renew_ip_non_owner_panics — auth rejection for non-owner
