### PR TITLE
feat: Implement Issues #428, #429, #430, #431 — IP Registry Enhancements                                                                                                                   feat: Implement Issues #428, #429, #430, #431 — IP Registry Enhancements                                                                                                                      issues 428 429 430 431

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,7 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 name = "ip_registry"
 version = "0.1.0"
 dependencies = [
+ "ed25519-dalek",
  "soroban-sdk",
 ]
 

--- a/contracts/ip_registry/Cargo.toml
+++ b/contracts/ip_registry/Cargo.toml
@@ -14,3 +14,4 @@ testutils = ["soroban-sdk/testutils"]
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }

--- a/contracts/ip_registry/src/lib.rs
+++ b/contracts/ip_registry/src/lib.rs
@@ -93,6 +93,8 @@ pub enum DataKey {
     OwnershipChallenge(u64), // Issue #433: stores OwnershipChallenge for a given challenge_id
     NextChallengeId,         // Issue #433: monotonic challenge ID counter
     EncryptionKeyRotation(u64), // Issue #434: stores rotation history for a given ip_id
+    NotaryPublicKey,        // Issue #428: stores the trusted notary Ed25519 public key (32 bytes)
+    CommitmentHashes,       // Issue #429: stores Vec<BytesN<32>> of all commitment hashes for rollback protection
 }
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -1250,6 +1252,27 @@ impl IpRegistry {
         Self::create_ip_version(env, parent_ip_id, commitment_hash)
     }
 
+    /// Get all direct child version IDs for a given IP.
+    ///
+    /// Returns the IDs of all IPs that were created as direct versions of `ip_id`
+    /// via `create_ip_version` or `commit_ip_version`. Does not include
+    /// grandchildren or deeper descendants.
+    ///
+    /// # Returns
+    ///
+    /// A `Vec<u64>` of direct child version IDs, or an empty vec if none exist.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the IP record does not exist (IpNotFound error).
+    pub fn get_ip_versions(env: Env, ip_id: u64) -> Vec<u64> {
+        require_ip_exists(&env, ip_id);
+        env.storage()
+            .persistent()
+            .get(&DataKey::IpVersions(ip_id))
+            .unwrap_or(Vec::new(&env))
+    }
+
     /// Retrieve the full version chain for an IP, rooted at the original.
     ///
     /// Returns a `Vec<u64>` starting with the root IP ID followed by all
@@ -1560,14 +1583,75 @@ impl IpRegistry {
             .unwrap_or(Vec::new(&env))
     }
 
-    // ── Issue #345: Timestamp Notarization ─────────────────────────────────────
+    // ── Issue #345 / #428: Timestamp Notarization ──────────────────────────────
 
-    /// Notarize an IP timestamp with a notary signature. Notary-only.
+    /// Set the trusted notary public key (Ed25519, 32 bytes). Admin-only.
+    ///
+    /// Must be called once after deployment to configure the notary public key
+    /// used to verify timestamp signatures.
+    pub fn set_notary_public_key(env: Env, public_key: BytesN<32>) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| env.current_contract_address());
+        admin.require_auth();
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::NotaryPublicKey, &public_key);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::NotaryPublicKey, LEDGER_BUMP, LEDGER_BUMP);
+    }
+
+    /// Notarize an IP timestamp with a notary Ed25519 signature.
+    ///
+    /// The notary must sign the message `ip_id_be_bytes || timestamp_be_bytes`
+    /// (8 bytes each, big-endian) with the private key corresponding to the
+    /// stored notary public key. The 64-byte signature is verified on-chain.
+    ///
+    /// # Panics
+    ///
+    /// Panics if:
+    /// * The IP does not exist (IpNotFound error)
+    /// * The notary public key has not been set (Unauthorized error)
+    /// * The signature is not exactly 64 bytes (Unauthorized error)
+    /// * The Ed25519 signature verification fails (Unauthorized error)
     pub fn notarize_ip_timestamp(env: Env, ip_id: u64, notary_signature: Bytes) {
         let mut record = require_ip_exists(&env, ip_id);
 
-        // In production, verify notary_signature against NOTARY_PUBLIC_KEY
-        // For now, accept any signature (placeholder implementation)
+        // Require notary public key to be configured
+        let public_key: BytesN<32> = match env
+            .storage()
+            .persistent()
+            .get(&DataKey::NotaryPublicKey)
+        {
+            Some(k) => k,
+            None => {
+                env.panic_with_error(Error::from_contract_error(ContractError::Unauthorized as u32));
+            }
+        };
+
+        // Signature must be exactly 64 bytes for Ed25519
+        if notary_signature.len() != 64 {
+            env.panic_with_error(Error::from_contract_error(ContractError::Unauthorized as u32));
+        }
+        let sig: BytesN<64> = match notary_signature.clone().try_into() {
+            Ok(s) => s,
+            Err(_) => {
+                env.panic_with_error(Error::from_contract_error(ContractError::Unauthorized as u32));
+            }
+        };
+
+        // Message: ip_id (8 bytes BE) || timestamp (8 bytes BE)
+        let mut message = Bytes::new(&env);
+        message.append(&Bytes::from_array(&env, &ip_id.to_be_bytes()));
+        message.append(&Bytes::from_array(&env, &record.timestamp.to_be_bytes()));
+
+        // Verify Ed25519 signature — panics if invalid
+        env.crypto().ed25519_verify(&public_key, &message, &sig);
+
         record.notary_signature = Some(notary_signature.clone());
 
         env.storage()
@@ -1614,26 +1698,61 @@ impl IpRegistry {
 
     // get_ip_disputes removed - IpDisputes DataKey variant not defined
 
-    // ── Issue #346: Commitment Rollback Protection ─────────────────────────────
+    // ── Issue #346 / #429: Commitment Rollback Protection ─────────────────────
 
     /// Compute and store a checksum of all commitments for rollback protection.
+    ///
+    /// Appends the latest commitment hash to the tracked list, then recomputes
+    /// the checksum as sha256 of all concatenated commitment hashes.
     fn update_commitment_checksum(env: &Env) {
-        // Get all commitment hashes from storage
-        // For simplicity, we compute a hash of all commitment hashes
-        let all_hashes = Bytes::new(env);
-
-        // This is a simplified implementation - in production, you'd iterate through all IPs
-        // For now, we'll store a placeholder checksum
-        let checksum: BytesN<32> = env.crypto().sha256(&all_hashes).into();
-
-        env.storage()
+        // Retrieve the current next ID to find the most recently added commitment
+        let next_id: u64 = env
+            .storage()
             .persistent()
-            .set(&DataKey::IpCommitmentChecksum, &checksum);
-        env.storage().persistent().extend_ttl(
-            &DataKey::IpCommitmentChecksum,
-            LEDGER_BUMP,
-            LEDGER_BUMP,
-        );
+            .get(&DataKey::NextId)
+            .unwrap_or(1);
+
+        // The last committed IP ID is next_id - 1 (if any IPs exist)
+        if next_id <= 1 {
+            return;
+        }
+        let last_id = next_id - 1;
+
+        // Get the commitment hash of the last committed IP
+        let last_record: Option<IpRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::IpRecord(last_id));
+
+        if let Some(record) = last_record {
+            // Append to tracked commitment hashes list
+            let mut hashes: Vec<BytesN<32>> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::CommitmentHashes)
+                .unwrap_or(Vec::new(env));
+            hashes.push_back(record.commitment_hash);
+            env.storage()
+                .persistent()
+                .set(&DataKey::CommitmentHashes, &hashes);
+            env.storage()
+                .persistent()
+                .extend_ttl(&DataKey::CommitmentHashes, LEDGER_BUMP, LEDGER_BUMP);
+
+            // Recompute checksum: sha256 of all concatenated commitment hashes
+            let mut all_bytes = Bytes::new(env);
+            for h in hashes.iter() {
+                all_bytes.append(&h.into());
+            }
+            let checksum: BytesN<32> = env.crypto().sha256(&all_bytes).into();
+
+            env.storage()
+                .persistent()
+                .set(&DataKey::IpCommitmentChecksum, &checksum);
+            env.storage()
+                .persistent()
+                .extend_ttl(&DataKey::IpCommitmentChecksum, LEDGER_BUMP, LEDGER_BUMP);
+        }
     }
 
     // ── Issue #439: Commitment Deduplication ──────────────────────────────────
@@ -1819,22 +1938,81 @@ impl IpRegistry {
     }
 
     /// Verify the integrity of all commitments (for upgrade safety).
+    ///
+    /// Recomputes the checksum from the tracked commitment hashes list and
+    /// compares it to the stored checksum. Returns `true` if they match.
     pub fn verify_commitment_integrity(env: Env) -> bool {
-        // Retrieve stored checksum
         let stored_checksum: Option<BytesN<32>> = env
             .storage()
             .persistent()
             .get(&DataKey::IpCommitmentChecksum);
 
         if stored_checksum.is_none() {
-            return true; // No checksum stored yet
+            return true; // No checksum stored yet — nothing to verify
         }
 
-        // Recompute checksum
-        let all_hashes = Bytes::new(&env);
-        let recomputed_checksum: BytesN<32> = env.crypto().sha256(&all_hashes).into();
+        let hashes: Vec<BytesN<32>> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CommitmentHashes)
+            .unwrap_or(Vec::new(&env));
 
-        stored_checksum.unwrap() == recomputed_checksum
+        let mut all_bytes = Bytes::new(&env);
+        for h in hashes.iter() {
+            all_bytes.append(&h.into());
+        }
+        let recomputed: BytesN<32> = env.crypto().sha256(&all_bytes).into();
+
+        stored_checksum.unwrap() == recomputed
+    }
+
+    // ── Issue #431: IP Claim Expiration Warnings ───────────────────────────────
+
+    /// Check if an IP commitment is approaching expiration and emit a warning event.
+    ///
+    /// Compares the remaining TTL of the IP record against `warning_threshold_ledgers`.
+    /// If the remaining TTL is less than or equal to the threshold, emits an
+    /// `exp_warn` event and returns `true`. Otherwise returns `false`.
+    ///
+    /// The TTL is estimated as `LEDGER_BUMP` minus ledgers elapsed since commitment
+    /// (using ledger sequence numbers as a proxy).
+    ///
+    /// # Arguments
+    ///
+    /// * `ip_id` - The IP to check
+    /// * `warning_threshold_ledgers` - Warn if remaining TTL ≤ this many ledgers
+    ///
+    /// # Returns
+    ///
+    /// `true` if the IP is approaching expiration, `false` otherwise.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the IP record does not exist (IpNotFound error).
+    pub fn check_expiration_warning(env: Env, ip_id: u64, warning_threshold_ledgers: u32) -> bool {
+        let record = require_ip_exists(&env, ip_id);
+
+        // Estimate remaining TTL: LEDGER_BUMP minus ledgers elapsed since commit.
+        // We use ledger sequence as a proxy for elapsed time.
+        // The record was committed at some ledger; we stored LEDGER_BUMP TTL at that point.
+        // Current sequence - commit sequence ≈ ledgers elapsed.
+        // Since we don't store the commit ledger sequence, we use timestamp difference
+        // as a proxy: elapsed_seconds / 5 ≈ elapsed_ledgers (5s per ledger).
+        let current_timestamp = env.ledger().timestamp();
+        let commit_timestamp = record.timestamp;
+        let elapsed_seconds = current_timestamp.saturating_sub(commit_timestamp);
+        let elapsed_ledgers = (elapsed_seconds / 5) as u32;
+        let remaining_ttl = LEDGER_BUMP.saturating_sub(elapsed_ledgers);
+
+        if remaining_ttl <= warning_threshold_ledgers {
+            env.events().publish(
+                (symbol_short!("exp_warn"), ip_id),
+                (record.owner, remaining_ttl),
+            );
+            return true;
+        }
+
+        false
     }
 
     // ── Issue #433: IP Ownership Proof Challenge ───────────────────────────────

--- a/contracts/ip_registry/src/test.rs
+++ b/contracts/ip_registry/src/test.rs
@@ -60,6 +60,14 @@ mod tests {
         fn generate_merkle_proof(env: Env, ip_id: u64) -> Vec<BytesN<32>>;
         fn compute_ip_merkle_root(env: Env, owner: Address) -> BytesN<32>;
         fn verify_ip_merkle_proof(env: Env, ip_id: u64, proof: Vec<BytesN<32>>) -> bool;
+        fn set_notary_public_key(env: Env, public_key: BytesN<32>);
+        fn notarize_ip_timestamp(env: Env, ip_id: u64, notary_signature: soroban_sdk::Bytes);
+        fn get_ip_notary_signature(env: Env, ip_id: u64) -> Option<soroban_sdk::Bytes>;
+        fn verify_commitment_integrity(env: Env) -> bool;
+        fn get_ip_versions(env: Env, ip_id: u64) -> Vec<u64>;
+        fn get_ip_lineage(env: Env, ip_id: u64) -> Vec<u64>;
+        fn get_ip_version_chain(env: Env, ip_id: u64) -> Vec<u64>;
+        fn check_expiration_warning(env: Env, ip_id: u64, warning_threshold_ledgers: u32) -> bool;
     }
 
     #[test]
@@ -1073,10 +1081,12 @@ mod tests {
         );
     }
 
-    // ── Issue #432: Batch Commitment Verification ──────────────────────────────
+    // ── Tests for Issue #428: Commitment Timestamp Notarization ──────────────
 
     #[test]
-    fn test_batch_verify_commitments_all_valid() {
+    fn test_notarize_ip_timestamp_with_valid_signature() {
+        use ed25519_dalek::{Signer, SigningKey};
+
         let env = Env::default();
         env.mock_all_auths();
         let contract_id = env.register(crate::IpRegistry, ());
@@ -1163,29 +1173,23 @@ mod tests {
         let owner = <Address as TestAddress>::generate(&env);
         let challenger = <Address as TestAddress>::generate(&env);
 
-        // Commit an IP
         let hash = BytesN::from_array(&env, &[0xA1u8; 32]);
         let ip_id = client.commit_ip(&owner, &hash, &0u32);
 
-        // Issue a challenge
         let nonce = BytesN::from_array(&env, &[0x42u8; 32]);
         let challenge_id = client.issue_ownership_challenge(&ip_id, &challenger, &nonce);
         assert_eq!(challenge_id, 1u64);
 
-        // Owner computes response: sha256(commitment_hash || nonce)
         let mut preimage = soroban_sdk::Bytes::new(&env);
         preimage.append(&hash.clone().into());
         preimage.append(&nonce.clone().into());
         let response: BytesN<32> = env.crypto().sha256(&preimage).into();
 
-        // Owner responds
         client.respond_to_ownership_challenge(&challenge_id, &response);
 
-        // Verify the challenge
         let valid = client.verify_ownership_challenge(&challenge_id);
         assert!(valid);
 
-        // Challenge should be marked verified
         let stored = client.get_ownership_challenge(&challenge_id).unwrap();
         assert!(stored.verified);
         assert_eq!(stored.ip_id, ip_id);
@@ -1207,7 +1211,6 @@ mod tests {
         let nonce = BytesN::from_array(&env, &[0x11u8; 32]);
         let challenge_id = client.issue_ownership_challenge(&ip_id, &challenger, &nonce);
 
-        // Wrong response
         let wrong_response = BytesN::from_array(&env, &[0xFFu8; 32]);
         client.respond_to_ownership_challenge(&challenge_id, &wrong_response);
 
@@ -1231,7 +1234,6 @@ mod tests {
         let nonce = BytesN::from_array(&env, &[0x22u8; 32]);
         let challenge_id = client.issue_ownership_challenge(&ip_id, &challenger, &nonce);
 
-        // No response submitted — verify should return false
         let valid = client.verify_ownership_challenge(&challenge_id);
         assert!(!valid);
     }
@@ -1247,7 +1249,6 @@ mod tests {
 
         let owner = <Address as TestAddress>::generate(&env);
 
-        // Commit with known secret/blinding_factor
         let secret = BytesN::from_array(&env, &[0x10u8; 32]);
         let bf = BytesN::from_array(&env, &[0x20u8; 32]);
         let mut pre = soroban_sdk::Bytes::new(&env);
@@ -1256,19 +1257,50 @@ mod tests {
         let old_hash: BytesN<32> = env.crypto().sha256(&pre).into();
         let ip_id = client.commit_ip(&owner, &old_hash, &0u32);
 
-        // New commitment hash (different value)
         let new_hash = BytesN::from_array(&env, &[0xD1u8; 32]);
-
         client.rotate_commitment_key(&ip_id, &new_hash, &secret, &bf);
 
-        // Record should now have new hash
         let record = client.get_ip(&ip_id);
         assert_eq!(record.commitment_hash, new_hash);
 
-        // Old hash should be in rotation history
         let history = client.get_key_rotation_history(&ip_id);
         assert_eq!(history.len(), 1);
         assert_eq!(history.get(0).unwrap(), old_hash);
+    }
+
+    // ── Tests for Issue #428: Commitment Timestamp Notarization (continued) ──
+
+    #[test]
+    fn test_notarize_ip_timestamp_with_valid_signature() {
+        use ed25519_dalek::{Signer, SigningKey};
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[50u8; 32]);
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
+
+        let signing_key = SigningKey::from_bytes(&[42u8; 32]);
+        let verifying_key = signing_key.verifying_key();
+        let public_key = BytesN::from_array(&env, verifying_key.as_bytes());
+
+        client.set_notary_public_key(&public_key);
+
+        let record = client.get_ip(&ip_id);
+        let mut msg_bytes = [0u8; 16];
+        msg_bytes[..8].copy_from_slice(&ip_id.to_be_bytes());
+        msg_bytes[8..].copy_from_slice(&record.timestamp.to_be_bytes());
+
+        let sig = signing_key.sign(&msg_bytes);
+        let notary_sig = soroban_sdk::Bytes::from_slice(&env, &sig.to_bytes());
+
+        client.notarize_ip_timestamp(&ip_id, &notary_sig);
+
+        let stored_sig = client.get_ip_notary_signature(&ip_id);
+        assert!(stored_sig.is_some());
     }
 
     #[test]
@@ -1292,7 +1324,6 @@ mod tests {
         let new_hash = BytesN::from_array(&env, &[0xE1u8; 32]);
         let wrong_secret = BytesN::from_array(&env, &[0xFFu8; 32]);
 
-        // Should panic: wrong old secret
         client.rotate_commitment_key(&ip_id, &new_hash, &wrong_secret, &bf);
     }
 
@@ -1309,7 +1340,6 @@ mod tests {
         let hash = BytesN::from_array(&env, &[0xF1u8; 32]);
         let ip_id = client.commit_ip(&owner, &hash, &0u32);
 
-        // Single leaf: proof is empty
         let proof = client.generate_merkle_proof(&ip_id);
         assert_eq!(proof.len(), 0);
     }
@@ -1331,7 +1361,6 @@ mod tests {
         let id2 = client.commit_ip(&owner, &h2, &0u32);
         let id3 = client.commit_ip(&owner, &h3, &0u32);
 
-        // Generate proof for each IP and verify it
         let proof1 = client.generate_merkle_proof(&id1);
         let proof2 = client.generate_merkle_proof(&id2);
         let proof3 = client.generate_merkle_proof(&id3);
@@ -1358,14 +1387,12 @@ mod tests {
 
         let root = client.compute_ip_merkle_root(&owner);
 
-        // Both proofs should verify against the same root
         let proof1 = client.generate_merkle_proof(&id1);
         let proof2 = client.generate_merkle_proof(&id2);
 
         assert!(client.verify_ip_merkle_proof(&id1, &proof1));
         assert!(client.verify_ip_merkle_proof(&id2, &proof2));
 
-        // Root should be non-zero
         let zero = BytesN::from_array(&env, &[0u8; 32]);
         assert_ne!(root, zero);
     }
@@ -1437,6 +1464,28 @@ mod tests {
 
     #[test]
     #[should_panic]
+    fn test_notarize_ip_timestamp_invalid_signature_panics() {
+        use ed25519_dalek::SigningKey;
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[51u8; 32]);
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
+
+        let signing_key = SigningKey::from_bytes(&[43u8; 32]);
+        let public_key = BytesN::from_array(&env, signing_key.verifying_key().as_bytes());
+        client.set_notary_public_key(&public_key);
+
+        let bad_sig = soroban_sdk::Bytes::from_array(&env, &[0u8; 64]);
+        client.notarize_ip_timestamp(&ip_id, &bad_sig);
+    }
+
+    #[test]
+    #[should_panic]
     fn test_submit_evidence_by_non_party_panics() {
         let env = Env::default();
         let contract_id = env.register(crate::IpRegistry, ());
@@ -1453,7 +1502,6 @@ mod tests {
             &BytesN::from_array(&env, &[0x33u8; 32]),
         );
 
-        // Stranger is neither owner nor challenger — must panic
         client.submit_dispute_evidence(
             &dispute_id,
             &stranger,
@@ -1486,6 +1534,22 @@ mod tests {
 
     #[test]
     #[should_panic]
+    fn test_notarize_ip_timestamp_no_public_key_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[52u8; 32]);
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
+
+        let sig = soroban_sdk::Bytes::from_array(&env, &[0u8; 64]);
+        client.notarize_ip_timestamp(&ip_id, &sig);
+    }
+
+    #[test]
+    #[should_panic]
     fn test_resolve_dispute_twice_panics() {
         let env = Env::default();
         let contract_id = env.register(crate::IpRegistry, ());
@@ -1502,7 +1566,6 @@ mod tests {
         );
 
         client.resolve_dispute(&dispute_id, &owner);
-        // Second resolve must panic (DisputeAlreadyResolved)
         client.resolve_dispute(&dispute_id, &challenger);
     }
 
@@ -1543,5 +1606,223 @@ mod tests {
             false
         });
         assert!(found, "dispute event must be emitted; dispute_id={dispute_id}");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_notarize_ip_timestamp_wrong_sig_length_panics() {
+        use ed25519_dalek::SigningKey;
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[53u8; 32]);
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
+
+        let signing_key = SigningKey::from_bytes(&[44u8; 32]);
+        let public_key = BytesN::from_array(&env, signing_key.verifying_key().as_bytes());
+        client.set_notary_public_key(&public_key);
+
+        let bad_sig = soroban_sdk::Bytes::from_array(&env, &[1u8; 32]);
+        client.notarize_ip_timestamp(&ip_id, &bad_sig);
+    }
+
+    // ── Tests for Issue #429: IP Rollback Protection ──────────────────────────
+
+    #[test]
+    fn test_commitment_checksum_updated_on_commit() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+
+        assert!(client.verify_commitment_integrity());
+
+        let commitment1 = BytesN::from_array(&env, &[60u8; 32]);
+        client.commit_ip(&owner, &commitment1, &0u32);
+        assert!(client.verify_commitment_integrity());
+
+        let commitment2 = BytesN::from_array(&env, &[61u8; 32]);
+        client.commit_ip(&owner, &commitment2, &0u32);
+        assert!(client.verify_commitment_integrity());
+    }
+
+    #[test]
+    fn test_commitment_checksum_reflects_all_commitments() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[62u8; 32]);
+        client.commit_ip(&owner, &commitment, &0u32);
+
+        let result1 = client.verify_commitment_integrity();
+        let result2 = client.verify_commitment_integrity();
+        assert_eq!(result1, result2);
+    }
+
+    // ── Tests for Issue #430: IP Commitment Versioning ────────────────────────
+
+    #[test]
+    fn test_get_ip_versions_returns_direct_children() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment1 = BytesN::from_array(&env, &[70u8; 32]);
+        let ip_id = client.commit_ip(&owner, &commitment1, &0u32);
+
+        let versions = client.get_ip_versions(&ip_id);
+        assert_eq!(versions.len(), 0);
+
+        let commitment2 = BytesN::from_array(&env, &[71u8; 32]);
+        let v1 = client.commit_ip_version(&owner, &commitment2, &ip_id);
+
+        let commitment3 = BytesN::from_array(&env, &[72u8; 32]);
+        let v2 = client.commit_ip_version(&owner, &commitment3, &ip_id);
+
+        let versions = client.get_ip_versions(&ip_id);
+        assert_eq!(versions.len(), 2);
+        assert_eq!(versions.get(0).unwrap(), v1);
+        assert_eq!(versions.get(1).unwrap(), v2);
+    }
+
+    #[test]
+    fn test_get_ip_versions_empty_for_no_versions() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[73u8; 32]);
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
+
+        let versions = client.get_ip_versions(&ip_id);
+        assert_eq!(versions.len(), 0);
+    }
+
+    #[test]
+    fn test_get_ip_lineage_includes_root_and_versions() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment1 = BytesN::from_array(&env, &[74u8; 32]);
+        let root_id = client.commit_ip(&owner, &commitment1, &0u32);
+
+        let commitment2 = BytesN::from_array(&env, &[75u8; 32]);
+        let v1 = client.commit_ip_version(&owner, &commitment2, &root_id);
+
+        let lineage = client.get_ip_lineage(&root_id);
+        assert!(lineage.len() >= 2);
+        assert_eq!(lineage.get(0).unwrap(), root_id);
+
+        let mut found = false;
+        for i in 0..lineage.len() {
+            if lineage.get(i).unwrap() == v1 { found = true; break; }
+        }
+        assert!(found, "v1 should be in lineage");
+    }
+
+    #[test]
+    fn test_get_ip_version_chain_includes_all() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment1 = BytesN::from_array(&env, &[76u8; 32]);
+        let root_id = client.commit_ip(&owner, &commitment1, &0u32);
+
+        let commitment2 = BytesN::from_array(&env, &[77u8; 32]);
+        let v1 = client.commit_ip_version(&owner, &commitment2, &root_id);
+
+        let chain = client.get_ip_version_chain(&root_id);
+        assert!(chain.len() >= 2);
+        assert_eq!(chain.get(0).unwrap(), root_id);
+
+        let mut found_v1 = false;
+        for i in 0..chain.len() {
+            if chain.get(i).unwrap() == v1 { found_v1 = true; break; }
+        }
+        assert!(found_v1, "v1 should be in version chain");
+    }
+
+    // ── Tests for Issue #431: IP Claim Expiration Warnings ───────────────────
+
+    #[test]
+    fn test_check_expiration_warning_not_expiring() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[80u8; 32]);
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
+
+        let is_expiring = client.check_expiration_warning(&ip_id, &1u32);
+        assert!(!is_expiring, "Newly committed IP should not be expiring");
+    }
+
+    #[test]
+    fn test_check_expiration_warning_large_threshold() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[81u8; 32]);
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
+
+        let is_expiring = client.check_expiration_warning(&ip_id, &(crate::LEDGER_BUMP + 1));
+        assert!(is_expiring, "IP should be expiring when threshold > LEDGER_BUMP");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_check_expiration_warning_nonexistent_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+        client.check_expiration_warning(&999u64, &100u32);
+    }
+
+    #[test]
+    fn test_check_expiration_warning_emits_event_when_expiring() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[82u8; 32]);
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
+
+        let _ = env.events().all();
+
+        let is_expiring = client.check_expiration_warning(&ip_id, &(crate::LEDGER_BUMP + 1));
+        assert!(is_expiring);
+
+        let events = env.events().all();
+        assert!(events.len() > 0, "Expiration warning event should be emitted");
+        let event = events.get(0).unwrap();
+        let expected_topics = (symbol_short!("exp_warn"), ip_id).into_val(&env);
+        assert_eq!(event.1, expected_topics);
     }
 }

--- a/contracts/ip_registry/src/types.rs
+++ b/contracts/ip_registry/src/types.rs
@@ -42,6 +42,8 @@ pub enum DataKey {
     NextChallengeId,         // Issue #433: monotonic challenge ID counter
     EncryptionKeyRotation(u64), // Issue #434: stores Vec<BytesN<32>> of old commitment hashes
     MerkleRoot(Address),     // Issue #435: cached Merkle root for an owner's commitment set
+    NotaryPublicKey,         // Issue #428: stores the trusted notary Ed25519 public key (32 bytes)
+    CommitmentHashes,        // Issue #429: stores Vec<BytesN<32>> of all commitment hashes for rollback protection
 }
 
 // ── Types ────────────────────────────────────────────────────────────────────

--- a/contracts/ip_registry/test_snapshots/differential_tests/differential_tests/differential_commitment_hash_matches_python_sha256.1.json
+++ b/contracts/ip_registry/test_snapshots/differential_tests/differential_tests/differential_commitment_hash_matches_python_sha256.1.json
@@ -88,6 +88,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "f818afd37a6dc3bc92fb44731011277006db4efa6e9023cd7468c02335d22a4d"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -156,7 +199,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "39ce20bede82c96b8908bec4a157b09c549b3db90b9b474bda9ae9b9030310b4"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/differential_tests/differential_tests/differential_id_sequence_matches_python_reference.1.json
+++ b/contracts/ip_registry/test_snapshots/differential_tests/differential_tests/differential_id_sequence_matches_python_reference.1.json
@@ -137,6 +137,55 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                    },
+                    {
+                      "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                    },
+                    {
+                      "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -295,7 +344,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "8a2e491356cfdb05a1d13785e0794d7cd163f91af79a146c976b1d2ac643b679"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/differential_tests/differential_tests/differential_verify_rejects_wrong_blinding_like_python.1.json
+++ b/contracts/ip_registry/test_snapshots/differential_tests/differential_tests/differential_verify_rejects_wrong_blinding_like_python.1.json
@@ -88,6 +88,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "f818afd37a6dc3bc92fb44731011277006db4efa6e9023cd7468c02335d22a4d"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -156,7 +199,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "39ce20bede82c96b8908bec4a157b09c549b3db90b9b474bda9ae9b9030310b4"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/differential_tests/differential_tests/differential_verify_rejects_wrong_secret_like_python.1.json
+++ b/contracts/ip_registry/test_snapshots/differential_tests/differential_tests/differential_verify_rejects_wrong_secret_like_python.1.json
@@ -88,6 +88,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "f818afd37a6dc3bc92fb44731011277006db4efa6e9023cd7468c02335d22a4d"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -156,7 +199,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "39ce20bede82c96b8908bec4a157b09c549b3db90b9b474bda9ae9b9030310b4"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/mutation_tests/mutation_tests/double_revoke_is_rejected.1.json
+++ b/contracts/ip_registry/test_snapshots/mutation_tests/mutation_tests/double_revoke_is_rejected.1.json
@@ -107,6 +107,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "1111111111111111111111111111111111111111111111111111111111111111"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -175,7 +218,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "02d449a31fbb267c8f352e9968a79e3e5fc95c1bbeaa502fd6454ebde5a4bedc"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/mutation_tests/mutation_tests/duplicate_hash_is_rejected.1.json
+++ b/contracts/ip_registry/test_snapshots/mutation_tests/mutation_tests/duplicate_hash_is_rejected.1.json
@@ -88,6 +88,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -156,7 +199,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "e0e77a507412b120f6ede61f62295b1a7b2ff19d3dcc8f7253e51663470c888e"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/mutation_tests/mutation_tests/ids_are_sequential_starting_at_one.1.json
+++ b/contracts/ip_registry/test_snapshots/mutation_tests/mutation_tests/ids_are_sequential_starting_at_one.1.json
@@ -137,6 +137,55 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                    },
+                    {
+                      "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                    },
+                    {
+                      "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -295,7 +344,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "8a2e491356cfdb05a1d13785e0794d7cd163f91af79a146c976b1d2ac643b679"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/mutation_tests/mutation_tests/non_zero_hash_is_accepted.1.json
+++ b/contracts/ip_registry/test_snapshots/mutation_tests/mutation_tests/non_zero_hash_is_accepted.1.json
@@ -87,6 +87,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -155,7 +198,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/mutation_tests/mutation_tests/owner_index_contains_committed_ids.1.json
+++ b/contracts/ip_registry/test_snapshots/mutation_tests/mutation_tests/owner_index_contains_committed_ids.1.json
@@ -113,6 +113,52 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "2020202020202020202020202020202020202020202020202020202020202020"
+                    },
+                    {
+                      "bytes": "2121212121212121212121212121212121212121212121212121212121212121"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -226,7 +272,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "93dfca11f79f74c1e8ce584fded63fa30b3c39ffdec5bb5a9d77f1d1dacc688c"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/mutation_tests/mutation_tests/revoked_flag_is_set_after_revoke.1.json
+++ b/contracts/ip_registry/test_snapshots/mutation_tests/mutation_tests/revoked_flag_is_set_after_revoke.1.json
@@ -107,6 +107,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -175,7 +218,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "baa501b37267c06d8d20f316622f90a3e343e9e730771f2ce2e314b794e31853"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/mutation_tests/mutation_tests/stored_commitment_hash_matches_input.1.json
+++ b/contracts/ip_registry/test_snapshots/mutation_tests/mutation_tests/stored_commitment_hash_matches_input.1.json
@@ -88,6 +88,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "4242424242424242424242424242424242424242424242424242424242424242"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -156,7 +199,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/mutation_tests/mutation_tests/verify_commitment_accepts_correct_secret.1.json
+++ b/contracts/ip_registry/test_snapshots/mutation_tests/mutation_tests/verify_commitment_accepts_correct_secret.1.json
@@ -88,6 +88,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "f818afd37a6dc3bc92fb44731011277006db4efa6e9023cd7468c02335d22a4d"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -156,7 +199,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "39ce20bede82c96b8908bec4a157b09c549b3db90b9b474bda9ae9b9030310b4"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/mutation_tests/mutation_tests/verify_commitment_rejects_wrong_secret.1.json
+++ b/contracts/ip_registry/test_snapshots/mutation_tests/mutation_tests/verify_commitment_rejects_wrong_secret.1.json
@@ -88,6 +88,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "f818afd37a6dc3bc92fb44731011277006db4efa6e9023cd7468c02335d22a4d"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -156,7 +199,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "39ce20bede82c96b8908bec4a157b09c549b3db90b9b474bda9ae9b9030310b4"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/snapshot_tests/snapshot_tests/snapshot_after_commit_ip.1.json
+++ b/contracts/ip_registry/test_snapshots/snapshot_tests/snapshot_tests/snapshot_after_commit_ip.1.json
@@ -88,6 +88,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "4242424242424242424242424242424242424242424242424242424242424242"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -156,7 +199,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "425ed4e4a36b30ea21b90e21c712c649e8214c29b7eaf68089d1039c6e55384c"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/snapshot_tests/snapshot_tests/snapshot_after_revoke_ip.1.json
+++ b/contracts/ip_registry/test_snapshots/snapshot_tests/snapshot_tests/snapshot_after_revoke_ip.1.json
@@ -107,6 +107,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "abababababababababababababababababababababababababababababababab"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -175,7 +218,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "9a2db2e23f1504cd056606553ac049c5e718e8f9ce9233876df1a7a1821af885"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/snapshot_tests/snapshot_tests/snapshot_existing_record_unchanged_after_new_commit.1.json
+++ b/contracts/ip_registry/test_snapshots/snapshot_tests/snapshot_tests/snapshot_existing_record_unchanged_after_new_commit.1.json
@@ -113,6 +113,52 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    },
+                    {
+                      "bytes": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -226,7 +272,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "e2d80f78d79027556d6619a1400605abbdca6bb6eb24e0831e33ecd5466fa5f6"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/snapshot_tests/snapshot_tests/snapshot_two_commits_independent_state.1.json
+++ b/contracts/ip_registry/test_snapshots/snapshot_tests/snapshot_tests/snapshot_two_commits_independent_state.1.json
@@ -114,6 +114,52 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                    },
+                    {
+                      "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -227,7 +273,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "f818afd37a6dc3bc92fb44731011277006db4efa6e9023cd7468c02335d22a4d"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_batch_commit_ip_five.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_batch_commit_ip_five.1.json
@@ -100,6 +100,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0505050505050505050505050505050505050505050505050505050505050505"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -348,7 +391,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "f849d67325facf04177bc663b2dc544051831c589ef581d412f2eba44834e77c"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_batch_commit_ip_sequential_with_single.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_batch_commit_ip_sequential_with_single.1.json
@@ -144,6 +144,55 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"
+                    },
+                    {
+                      "bytes": "0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d"
+                    },
+                    {
+                      "bytes": "0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -392,7 +441,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "106057b51e844f070b10b2cf82a071a0cee5dfab53dc090a0d8f9e6c0a9f3fe4"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_batch_commit_ip_single.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_batch_commit_ip_single.1.json
@@ -88,6 +88,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -156,7 +199,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_check_expiration_warning_emits_event_when_expiring.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_check_expiration_warning_emits_event_when_expiring.1.json
@@ -1,7 +1,7 @@
 {
   "generators": {
-    "address": 3,
-    "nonce": 1
+    "address": 2,
+    "nonce": 0
   },
   "auth": [
     [],
@@ -18,7 +18,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                  "bytes": "5252525252525252525252525252525252525252525252525252525252525252"
                 },
                 {
                   "u32": 0
@@ -30,7 +30,6 @@
         }
       ]
     ],
-    [],
     []
   ],
   "ledger": {
@@ -114,7 +113,7 @@
                 "val": {
                   "vec": [
                     {
-                      "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                      "bytes": "5252525252525252525252525252525252525252525252525252525252525252"
                     }
                   ]
                 }
@@ -135,7 +134,7 @@
                   "symbol": "CommitmentOwner"
                 },
                 {
-                  "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                  "bytes": "5252525252525252525252525252525252525252525252525252525252525252"
                 }
               ]
             },
@@ -155,7 +154,7 @@
                       "symbol": "CommitmentOwner"
                     },
                     {
-                      "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                      "bytes": "5252525252525252525252525252525252525252525252525252525252525252"
                     }
                   ]
                 },
@@ -200,7 +199,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "bca74ab50316fc13723f64b52b20b571a0c2f77a65f6e21773fd705f9876fdc4"
+                  "bytes": "16b72cfab7dbca73cb348f4e59a74b5c56d6e95574c1e9ca84850d69f5fa9430"
                 }
               }
             },
@@ -259,7 +258,7 @@
                         "symbol": "commitment_hash"
                       },
                       "val": {
-                        "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                        "bytes": "5252525252525252525252525252525252525252525252525252525252525252"
                       }
                     },
                     {
@@ -470,38 +469,6 @@
       ],
       [
         {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-            "key": "ledger_key_contract_instance",
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-                "key": "ledger_key_contract_instance",
-                "durability": "persistent",
-                "val": {
-                  "contract_instance": {
-                    "executable": {
-                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-                    },
-                    "storage": null
-                  }
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
-      [
-        {
           "contract_code": {
             "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
           }
@@ -523,5 +490,36 @@
       ]
     ]
   },
-  "events": []
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "exp_warn"
+              },
+              {
+                "u64": 1
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 6307200
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
 }

--- a/contracts/ip_registry/test_snapshots/test/tests/test_check_expiration_warning_large_threshold.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_check_expiration_warning_large_threshold.1.json
@@ -1,7 +1,7 @@
 {
   "generators": {
-    "address": 3,
-    "nonce": 1
+    "address": 2,
+    "nonce": 0
   },
   "auth": [
     [],
@@ -18,7 +18,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                  "bytes": "5151515151515151515151515151515151515151515151515151515151515151"
                 },
                 {
                   "u32": 0
@@ -30,7 +30,6 @@
         }
       ]
     ],
-    [],
     []
   ],
   "ledger": {
@@ -114,7 +113,7 @@
                 "val": {
                   "vec": [
                     {
-                      "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                      "bytes": "5151515151515151515151515151515151515151515151515151515151515151"
                     }
                   ]
                 }
@@ -135,7 +134,7 @@
                   "symbol": "CommitmentOwner"
                 },
                 {
-                  "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                  "bytes": "5151515151515151515151515151515151515151515151515151515151515151"
                 }
               ]
             },
@@ -155,7 +154,7 @@
                       "symbol": "CommitmentOwner"
                     },
                     {
-                      "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                      "bytes": "5151515151515151515151515151515151515151515151515151515151515151"
                     }
                   ]
                 },
@@ -200,7 +199,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "bca74ab50316fc13723f64b52b20b571a0c2f77a65f6e21773fd705f9876fdc4"
+                  "bytes": "2cf2c6077769e8f910ed119ac8fa288d12817d4fdcef245576c752a076d3217a"
                 }
               }
             },
@@ -259,7 +258,7 @@
                         "symbol": "commitment_hash"
                       },
                       "val": {
-                        "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                        "bytes": "5151515151515151515151515151515151515151515151515151515151515151"
                       }
                     },
                     {
@@ -470,38 +469,6 @@
       ],
       [
         {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-            "key": "ledger_key_contract_instance",
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-                "key": "ledger_key_contract_instance",
-                "durability": "persistent",
-                "val": {
-                  "contract_instance": {
-                    "executable": {
-                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-                    },
-                    "storage": null
-                  }
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
-      [
-        {
           "contract_code": {
             "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
           }
@@ -523,5 +490,36 @@
       ]
     ]
   },
-  "events": []
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "exp_warn"
+              },
+              {
+                "u64": 1
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 6307200
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
 }

--- a/contracts/ip_registry/test_snapshots/test/tests/test_check_expiration_warning_nonexistent_panics.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_check_expiration_warning_nonexistent_panics.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/ip_registry/test_snapshots/test/tests/test_check_expiration_warning_not_expiring.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_check_expiration_warning_not_expiring.1.json
@@ -1,7 +1,7 @@
 {
   "generators": {
-    "address": 3,
-    "nonce": 1
+    "address": 2,
+    "nonce": 0
   },
   "auth": [
     [],
@@ -18,7 +18,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                  "bytes": "5050505050505050505050505050505050505050505050505050505050505050"
                 },
                 {
                   "u32": 0
@@ -30,7 +30,6 @@
         }
       ]
     ],
-    [],
     []
   ],
   "ledger": {
@@ -114,7 +113,7 @@
                 "val": {
                   "vec": [
                     {
-                      "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                      "bytes": "5050505050505050505050505050505050505050505050505050505050505050"
                     }
                   ]
                 }
@@ -135,7 +134,7 @@
                   "symbol": "CommitmentOwner"
                 },
                 {
-                  "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                  "bytes": "5050505050505050505050505050505050505050505050505050505050505050"
                 }
               ]
             },
@@ -155,7 +154,7 @@
                       "symbol": "CommitmentOwner"
                     },
                     {
-                      "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                      "bytes": "5050505050505050505050505050505050505050505050505050505050505050"
                     }
                   ]
                 },
@@ -200,7 +199,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "bca74ab50316fc13723f64b52b20b571a0c2f77a65f6e21773fd705f9876fdc4"
+                  "bytes": "b37361a0be8af8905de1f4384e701365ece4313dd5e064d375eb2851c043ba68"
                 }
               }
             },
@@ -259,7 +258,7 @@
                         "symbol": "commitment_hash"
                       },
                       "val": {
-                        "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                        "bytes": "5050505050505050505050505050505050505050505050505050505050505050"
                       }
                     },
                     {
@@ -466,38 +465,6 @@
             "ext": "v0"
           },
           6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-            "key": "ledger_key_contract_instance",
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-                "key": "ledger_key_contract_instance",
-                "durability": "persistent",
-                "val": {
-                  "contract_instance": {
-                    "executable": {
-                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-                    },
-                    "storage": null
-                  }
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
         ]
       ],
       [

--- a/contracts/ip_registry/test_snapshots/test/tests/test_commit_ip_emits_event.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_commit_ip_emits_event.1.json
@@ -88,6 +88,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -156,7 +199,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "544e62cee8033709e389e5b2755343d0d0fa8c4850215cfb6331717e80d1aea3"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_commit_ip_pow_difficulty_eight_accepts_leading_zero_byte.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_commit_ip_pow_difficulty_eight_accepts_leading_zero_byte.1.json
@@ -87,6 +87,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0001010101010101010101010101010101010101010101010101010101010101"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -155,7 +198,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "915c75942a26bb3a433a8ce2cb0427c29ec6c1775cfc78328b57f6ba7bfeaa9c"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_commit_ip_pow_difficulty_four_accepts_half_zero_nibble.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_commit_ip_pow_difficulty_four_accepts_half_zero_nibble.1.json
@@ -87,6 +87,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0f01010101010101010101010101010101010101010101010101010101010101"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -155,7 +198,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "c943f9a5769967ceb4f04fc81e20903816daab6c34644e5ea1bfd6b6a013e037"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_commit_ip_pow_difficulty_zero_always_passes.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_commit_ip_pow_difficulty_zero_always_passes.1.json
@@ -87,6 +87,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -155,7 +198,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "af9613760f72635fbdb44a5a0a63c39f12af30f950a6ee5c971be188e89c4051"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_commit_ip_sequential_ids.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_commit_ip_sequential_ids.1.json
@@ -142,6 +142,55 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                    },
+                    {
+                      "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                    },
+                    {
+                      "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -300,7 +349,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "8a2e491356cfdb05a1d13785e0794d7cd163f91af79a146c976b1d2ac643b679"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_commitment_checksum_reflects_all_commitments.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_commitment_checksum_reflects_all_commitments.1.json
@@ -1,0 +1,495 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "commit_ip",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e"
+                },
+                {
+                  "u32": 0
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Admin"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Admin"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          50000
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CommitmentOwner"
+                },
+                {
+                  "bytes": "3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentOwner"
+                    },
+                    {
+                      "bytes": "3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "IpCommitmentChecksum"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "IpCommitmentChecksum"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "b59550bb3e711f3f1f8f2fe77c140278dfa7476a17547d41caf2e161f5c14437"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "IpRecord"
+                },
+                {
+                  "u64": 1
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "IpRecord"
+                    },
+                    {
+                      "u64": 1
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "co_owners"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "commitment_hash"
+                      },
+                      "val": {
+                        "bytes": "3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "ip_id"
+                      },
+                      "val": {
+                        "u64": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notary_signature"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "parent_ip_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "revoked"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "timestamp"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "NextId"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "NextId"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u64": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "OwnerIps"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "OwnerIps"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "u64": 1
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/ip_registry/test_snapshots/test/tests/test_commitment_checksum_updated_on_commit.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_commitment_checksum_updated_on_commit.1.json
@@ -1,0 +1,711 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "commit_ip",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c"
+                },
+                {
+                  "u32": 0
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "commit_ip",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d"
+                },
+                {
+                  "u32": 0
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Admin"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Admin"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          50000
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c"
+                    },
+                    {
+                      "bytes": "3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CommitmentOwner"
+                },
+                {
+                  "bytes": "3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentOwner"
+                    },
+                    {
+                      "bytes": "3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CommitmentOwner"
+                },
+                {
+                  "bytes": "3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentOwner"
+                    },
+                    {
+                      "bytes": "3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "IpCommitmentChecksum"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "IpCommitmentChecksum"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "72d563b2ca284e1e74155b2baa7915d0b0b167e6bf1e609f97d1ef0c3b667332"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "IpRecord"
+                },
+                {
+                  "u64": 1
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "IpRecord"
+                    },
+                    {
+                      "u64": 1
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "co_owners"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "commitment_hash"
+                      },
+                      "val": {
+                        "bytes": "3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "ip_id"
+                      },
+                      "val": {
+                        "u64": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notary_signature"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "parent_ip_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "revoked"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "timestamp"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "IpRecord"
+                },
+                {
+                  "u64": 2
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "IpRecord"
+                    },
+                    {
+                      "u64": 2
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "co_owners"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "commitment_hash"
+                      },
+                      "val": {
+                        "bytes": "3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "ip_id"
+                      },
+                      "val": {
+                        "u64": 2
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notary_signature"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "parent_ip_id"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "revoked"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "timestamp"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "NextId"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "NextId"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u64": 3
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "OwnerIps"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "OwnerIps"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "u64": 1
+                    },
+                    {
+                      "u64": 2
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/ip_registry/test_snapshots/test/tests/test_get_ip_lineage_includes_root_and_versions.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_get_ip_lineage_includes_root_and_versions.1.json
@@ -18,7 +18,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+                  "bytes": "4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a"
                 },
                 {
                   "u32": 0
@@ -30,7 +30,6 @@
         }
       ]
     ],
-    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
@@ -44,7 +43,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
+                  "bytes": "4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b"
                 },
                 {
                   "u64": 1
@@ -67,7 +66,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
+                  "bytes": "4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b"
                 },
                 {
                   "u64": 1
@@ -162,7 +161,7 @@
                 "val": {
                   "vec": [
                     {
-                      "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+                      "bytes": "4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a"
                     }
                   ]
                 }
@@ -183,7 +182,7 @@
                   "symbol": "CommitmentOwner"
                 },
                 {
-                  "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+                  "bytes": "4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a"
                 }
               ]
             },
@@ -203,7 +202,7 @@
                       "symbol": "CommitmentOwner"
                     },
                     {
-                      "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+                      "bytes": "4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a"
                     }
                   ]
                 },
@@ -228,7 +227,7 @@
                   "symbol": "CommitmentOwner"
                 },
                 {
-                  "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
+                  "bytes": "4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b"
                 }
               ]
             },
@@ -248,7 +247,7 @@
                       "symbol": "CommitmentOwner"
                     },
                     {
-                      "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
+                      "bytes": "4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b"
                     }
                   ]
                 },
@@ -293,7 +292,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "386435a7b3c19955717d9a6fd558895a25ad12ad03d73251d13d8fe66436486b"
+                  "bytes": "07a84af7b948e14dffc3a736b33d7661d80f672ae27f869c56fc15e629c98e6e"
                 }
               }
             },
@@ -352,7 +351,7 @@
                         "symbol": "commitment_hash"
                       },
                       "val": {
-                        "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+                        "bytes": "4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a4a"
                       }
                     },
                     {
@@ -458,7 +457,7 @@
                         "symbol": "commitment_hash"
                       },
                       "val": {
-                        "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
+                        "bytes": "4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b4b"
                       }
                     },
                     {

--- a/contracts/ip_registry/test_snapshots/test/tests/test_get_ip_version_chain_includes_all.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_get_ip_version_chain_includes_all.1.json
@@ -18,7 +18,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+                  "bytes": "4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c"
                 },
                 {
                   "u32": 0
@@ -30,7 +30,6 @@
         }
       ]
     ],
-    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
@@ -44,7 +43,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
+                  "bytes": "4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d"
                 },
                 {
                   "u64": 1
@@ -67,7 +66,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
+                  "bytes": "4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d"
                 },
                 {
                   "u64": 1
@@ -162,7 +161,7 @@
                 "val": {
                   "vec": [
                     {
-                      "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+                      "bytes": "4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c"
                     }
                   ]
                 }
@@ -183,7 +182,7 @@
                   "symbol": "CommitmentOwner"
                 },
                 {
-                  "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+                  "bytes": "4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c"
                 }
               ]
             },
@@ -203,7 +202,7 @@
                       "symbol": "CommitmentOwner"
                     },
                     {
-                      "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+                      "bytes": "4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c"
                     }
                   ]
                 },
@@ -228,7 +227,7 @@
                   "symbol": "CommitmentOwner"
                 },
                 {
-                  "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
+                  "bytes": "4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d"
                 }
               ]
             },
@@ -248,7 +247,7 @@
                       "symbol": "CommitmentOwner"
                     },
                     {
-                      "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
+                      "bytes": "4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d"
                     }
                   ]
                 },
@@ -293,7 +292,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "386435a7b3c19955717d9a6fd558895a25ad12ad03d73251d13d8fe66436486b"
+                  "bytes": "4be3e71945f328b2a03b3ca5015f49d9a9300aacba6e25276c1bf08fba68f3f3"
                 }
               }
             },
@@ -352,7 +351,7 @@
                         "symbol": "commitment_hash"
                       },
                       "val": {
-                        "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+                        "bytes": "4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c"
                       }
                     },
                     {
@@ -458,7 +457,7 @@
                         "symbol": "commitment_hash"
                       },
                       "val": {
-                        "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
+                        "bytes": "4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d"
                       }
                     },
                     {

--- a/contracts/ip_registry/test_snapshots/test/tests/test_get_ip_versions_empty_for_no_versions.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_get_ip_versions_empty_for_no_versions.1.json
@@ -18,59 +18,10 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+                  "bytes": "4949494949494949494949494949494949494949494949494949494949494949"
                 },
                 {
                   "u32": 0
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
-    [],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "commit_ip_version",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
-                },
-                {
-                  "u64": 1
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ],
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "commit_ip_version",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
-                },
-                {
-                  "u64": 1
                 }
               ]
             }
@@ -162,7 +113,7 @@
                 "val": {
                   "vec": [
                     {
-                      "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+                      "bytes": "4949494949494949494949494949494949494949494949494949494949494949"
                     }
                   ]
                 }
@@ -183,7 +134,7 @@
                   "symbol": "CommitmentOwner"
                 },
                 {
-                  "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+                  "bytes": "4949494949494949494949494949494949494949494949494949494949494949"
                 }
               ]
             },
@@ -203,52 +154,7 @@
                       "symbol": "CommitmentOwner"
                     },
                     {
-                      "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          6307200
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "CommitmentOwner"
-                },
-                {
-                  "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "CommitmentOwner"
-                    },
-                    {
-                      "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
+                      "bytes": "4949494949494949494949494949494949494949494949494949494949494949"
                     }
                   ]
                 },
@@ -293,7 +199,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "386435a7b3c19955717d9a6fd558895a25ad12ad03d73251d13d8fe66436486b"
+                  "bytes": "96079eae5f7d8d33a342209c04ceafd4212296c502e7fa7adfa4a91a13fede1e"
                 }
               }
             },
@@ -352,7 +258,7 @@
                         "symbol": "commitment_hash"
                       },
                       "val": {
-                        "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+                        "bytes": "4949494949494949494949494949494949494949494949494949494949494949"
                       }
                     },
                     {
@@ -398,215 +304,6 @@
                       "val": {
                         "u64": 0
                       }
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          6307200
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "IpRecord"
-                },
-                {
-                  "u64": 2
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "IpRecord"
-                    },
-                    {
-                      "u64": 2
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "co_owners"
-                      },
-                      "val": {
-                        "vec": []
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "commitment_hash"
-                      },
-                      "val": {
-                        "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "ip_id"
-                      },
-                      "val": {
-                        "u64": 2
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "notary_signature"
-                      },
-                      "val": "void"
-                    },
-                    {
-                      "key": {
-                        "symbol": "owner"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "parent_ip_id"
-                      },
-                      "val": {
-                        "u64": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "revoked"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "timestamp"
-                      },
-                      "val": {
-                        "u64": 0
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          6307200
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "IpVersionChain"
-                },
-                {
-                  "u64": 1
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "IpVersionChain"
-                    },
-                    {
-                      "u64": 1
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "vec": [
-                    {
-                      "u64": 1
-                    },
-                    {
-                      "u64": 2
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          6307200
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "IpVersions"
-                },
-                {
-                  "u64": 1
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "IpVersions"
-                    },
-                    {
-                      "u64": 1
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "vec": [
-                    {
-                      "u64": 2
                     }
                   ]
                 }
@@ -647,7 +344,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "u64": 3
+                  "u64": 2
                 }
               }
             },
@@ -695,9 +392,6 @@
                   "vec": [
                     {
                       "u64": 1
-                    },
-                    {
-                      "u64": 2
                     }
                   ]
                 }
@@ -762,72 +456,6 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 1033654523790656264
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 1033654523790656264
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 5541220902715666415
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
                   }
                 },
                 "durability": "temporary",

--- a/contracts/ip_registry/test_snapshots/test/tests/test_get_ip_versions_returns_direct_children.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_get_ip_versions_returns_direct_children.1.json
@@ -18,7 +18,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+                  "bytes": "4646464646464646464646464646464646464646464646464646464646464646"
                 },
                 {
                   "u32": 0
@@ -44,7 +44,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
+                  "bytes": "4747474747474747474747474747474747474747474747474747474747474747"
                 },
                 {
                   "u64": 1
@@ -67,7 +67,55 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
+                  "bytes": "4747474747474747474747474747474747474747474747474747474747474747"
+                },
+                {
+                  "u64": 1
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "commit_ip_version",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "4848484848484848484848484848484848484848484848484848484848484848"
+                },
+                {
+                  "u64": 1
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "commit_ip_version",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "4848484848484848484848484848484848484848484848484848484848484848"
                 },
                 {
                   "u64": 1
@@ -162,7 +210,7 @@
                 "val": {
                   "vec": [
                     {
-                      "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+                      "bytes": "4646464646464646464646464646464646464646464646464646464646464646"
                     }
                   ]
                 }
@@ -183,7 +231,7 @@
                   "symbol": "CommitmentOwner"
                 },
                 {
-                  "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+                  "bytes": "4646464646464646464646464646464646464646464646464646464646464646"
                 }
               ]
             },
@@ -203,7 +251,7 @@
                       "symbol": "CommitmentOwner"
                     },
                     {
-                      "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+                      "bytes": "4646464646464646464646464646464646464646464646464646464646464646"
                     }
                   ]
                 },
@@ -228,7 +276,7 @@
                   "symbol": "CommitmentOwner"
                 },
                 {
-                  "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
+                  "bytes": "4747474747474747474747474747474747474747474747474747474747474747"
                 }
               ]
             },
@@ -248,7 +296,52 @@
                       "symbol": "CommitmentOwner"
                     },
                     {
-                      "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
+                      "bytes": "4747474747474747474747474747474747474747474747474747474747474747"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CommitmentOwner"
+                },
+                {
+                  "bytes": "4848484848484848484848484848484848484848484848484848484848484848"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentOwner"
+                    },
+                    {
+                      "bytes": "4848484848484848484848484848484848484848484848484848484848484848"
                     }
                   ]
                 },
@@ -293,7 +386,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "386435a7b3c19955717d9a6fd558895a25ad12ad03d73251d13d8fe66436486b"
+                  "bytes": "ddd3c9e68bc7f05f01f584db9b1b4e27a0d1aa379a6bdcd6988235a515e94003"
                 }
               }
             },
@@ -352,7 +445,7 @@
                         "symbol": "commitment_hash"
                       },
                       "val": {
-                        "bytes": "d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+                        "bytes": "4646464646464646464646464646464646464646464646464646464646464646"
                       }
                     },
                     {
@@ -458,7 +551,7 @@
                         "symbol": "commitment_hash"
                       },
                       "val": {
-                        "bytes": "d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2"
+                        "bytes": "4747474747474747474747474747474747474747474747474747474747474747"
                       }
                     },
                     {
@@ -467,6 +560,114 @@
                       },
                       "val": {
                         "u64": 2
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notary_signature"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "parent_ip_id"
+                      },
+                      "val": {
+                        "u64": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "revoked"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "timestamp"
+                      },
+                      "val": {
+                        "u64": 0
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "IpRecord"
+                },
+                {
+                  "u64": 3
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "IpRecord"
+                    },
+                    {
+                      "u64": 3
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "co_owners"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "commitment_hash"
+                      },
+                      "val": {
+                        "bytes": "4848484848484848484848484848484848484848484848484848484848484848"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "ip_id"
+                      },
+                      "val": {
+                        "u64": 3
                       }
                     },
                     {
@@ -558,6 +759,9 @@
                     },
                     {
                       "u64": 2
+                    },
+                    {
+                      "u64": 3
                     }
                   ]
                 }
@@ -607,6 +811,9 @@
                   "vec": [
                     {
                       "u64": 2
+                    },
+                    {
+                      "u64": 3
                     }
                   ]
                 }
@@ -647,7 +854,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "u64": 3
+                  "u64": 4
                 }
               }
             },
@@ -698,6 +905,9 @@
                     },
                     {
                       "u64": 2
+                    },
+                    {
+                      "u64": 3
                     }
                   ]
                 }
@@ -795,6 +1005,72 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 2032731177588607455
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 2032731177588607455
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
                   }
                 },
                 "durability": "temporary",

--- a/contracts/ip_registry/test_snapshots/test/tests/test_get_partial_disclosure_none_before_reveal.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_get_partial_disclosure_none_before_reveal.1.json
@@ -88,6 +88,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "9999999999999999999999999999999999999999999999999999999999999999"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -156,7 +199,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "af834b2357bae6ad7eccd35c0a050538af38b19023275f58d1f3b39e4d1a0435"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_is_ip_owner.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_is_ip_owner.1.json
@@ -90,6 +90,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -158,7 +201,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "b9b07dd4e7718454476f04edeb935022ae4f4d90934ab7ce913ff20c8baeb399"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_list_ip_by_owner_returns_all_ids.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_list_ip_by_owner_returns_all_ids.1.json
@@ -138,6 +138,55 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0404040404040404040404040404040404040404040404040404040404040404"
+                    },
+                    {
+                      "bytes": "0505050505050505050505050505050505050505050505050505050505050505"
+                    },
+                    {
+                      "bytes": "0606060606060606060606060606060606060606060606060606060606060606"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -296,7 +345,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "1bcd87e9b1e97f374a89645629f7da5acaf08350dc62101cad9371147271e4b3"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_list_ip_by_owner_unknown_returns_empty.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_list_ip_by_owner_unknown_returns_empty.1.json
@@ -89,6 +89,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -157,7 +200,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_notarize_ip_timestamp_invalid_signature_panics.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_notarize_ip_timestamp_invalid_signature_panics.1.json
@@ -18,7 +18,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
+                  "bytes": "3333333333333333333333333333333333333333333333333333333333333333"
                 },
                 {
                   "u32": 0
@@ -32,46 +32,15 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "commit_ip",
+              "function_name": "set_notary_public_key",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "bytes": "1111111111111111111111111111111111111111111111111111111111111111"
-                },
-                {
-                  "u32": 0
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "commit_ip",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "bytes": "1212121212121212121212121212121212121212121212121212121212121212"
-                },
-                {
-                  "u32": 0
+                  "bytes": "4508a07aa941707f3eb2db94c8897a80b2c1197476b6de213ac273df7d86c4ff"
                 }
               ]
             }
@@ -163,13 +132,7 @@
                 "val": {
                   "vec": [
                     {
-                      "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
-                    },
-                    {
-                      "bytes": "1111111111111111111111111111111111111111111111111111111111111111"
-                    },
-                    {
-                      "bytes": "1212121212121212121212121212121212121212121212121212121212121212"
+                      "bytes": "3333333333333333333333333333333333333333333333333333333333333333"
                     }
                   ]
                 }
@@ -190,7 +153,7 @@
                   "symbol": "CommitmentOwner"
                 },
                 {
-                  "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
+                  "bytes": "3333333333333333333333333333333333333333333333333333333333333333"
                 }
               ]
             },
@@ -210,97 +173,7 @@
                       "symbol": "CommitmentOwner"
                     },
                     {
-                      "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          6307200
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "CommitmentOwner"
-                },
-                {
-                  "bytes": "1111111111111111111111111111111111111111111111111111111111111111"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "CommitmentOwner"
-                    },
-                    {
-                      "bytes": "1111111111111111111111111111111111111111111111111111111111111111"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          6307200
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "CommitmentOwner"
-                },
-                {
-                  "bytes": "1212121212121212121212121212121212121212121212121212121212121212"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "CommitmentOwner"
-                    },
-                    {
-                      "bytes": "1212121212121212121212121212121212121212121212121212121212121212"
+                      "bytes": "3333333333333333333333333333333333333333333333333333333333333333"
                     }
                   ]
                 },
@@ -345,7 +218,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "49123fe33eb96ec648e137640414dc361e3b86fa26c0f479d10ae5038bd07b63"
+                  "bytes": "deb0e38ced1e41de6f92e70e80c418d2d356afaaa99e26f5939dbc7d3ef4772a"
                 }
               }
             },
@@ -404,7 +277,7 @@
                         "symbol": "commitment_hash"
                       },
                       "val": {
-                        "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
+                        "bytes": "3333333333333333333333333333333333333333333333333333333333333333"
                       }
                     },
                     {
@@ -413,218 +286,6 @@
                       },
                       "val": {
                         "u64": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "notary_signature"
-                      },
-                      "val": "void"
-                    },
-                    {
-                      "key": {
-                        "symbol": "owner"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "parent_ip_id"
-                      },
-                      "val": "void"
-                    },
-                    {
-                      "key": {
-                        "symbol": "revoked"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "timestamp"
-                      },
-                      "val": {
-                        "u64": 0
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          6307200
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "IpRecord"
-                },
-                {
-                  "u64": 2
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "IpRecord"
-                    },
-                    {
-                      "u64": 2
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "co_owners"
-                      },
-                      "val": {
-                        "vec": []
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "commitment_hash"
-                      },
-                      "val": {
-                        "bytes": "1111111111111111111111111111111111111111111111111111111111111111"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "ip_id"
-                      },
-                      "val": {
-                        "u64": 2
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "notary_signature"
-                      },
-                      "val": "void"
-                    },
-                    {
-                      "key": {
-                        "symbol": "owner"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "parent_ip_id"
-                      },
-                      "val": "void"
-                    },
-                    {
-                      "key": {
-                        "symbol": "revoked"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "timestamp"
-                      },
-                      "val": {
-                        "u64": 0
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          6307200
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "IpRecord"
-                },
-                {
-                  "u64": 3
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "IpRecord"
-                    },
-                    {
-                      "u64": 3
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "co_owners"
-                      },
-                      "val": {
-                        "vec": []
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "commitment_hash"
-                      },
-                      "val": {
-                        "bytes": "1212121212121212121212121212121212121212121212121212121212121212"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "ip_id"
-                      },
-                      "val": {
-                        "u64": 3
                       }
                     },
                     {
@@ -702,7 +363,46 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "u64": 4
+                  "u64": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "NotaryPublicKey"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "NotaryPublicKey"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "4508a07aa941707f3eb2db94c8897a80b2c1197476b6de213ac273df7d86c4ff"
                 }
               }
             },
@@ -750,12 +450,6 @@
                   "vec": [
                     {
                       "u64": 1
-                    },
-                    {
-                      "u64": 2
-                    },
-                    {
-                      "u64": 3
                     }
                   ]
                 }
@@ -801,6 +495,39 @@
       [
         {
           "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
@@ -820,72 +547,6 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 1033654523790656264
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 1033654523790656264
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 5541220902715666415
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
                   }
                 },
                 "durability": "temporary",

--- a/contracts/ip_registry/test_snapshots/test/tests/test_notarize_ip_timestamp_no_public_key_panics.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_notarize_ip_timestamp_no_public_key_panics.1.json
@@ -1,7 +1,7 @@
 {
   "generators": {
-    "address": 3,
-    "nonce": 1
+    "address": 2,
+    "nonce": 0
   },
   "auth": [
     [],
@@ -18,7 +18,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                  "bytes": "3434343434343434343434343434343434343434343434343434343434343434"
                 },
                 {
                   "u32": 0
@@ -30,7 +30,6 @@
         }
       ]
     ],
-    [],
     []
   ],
   "ledger": {
@@ -114,7 +113,7 @@
                 "val": {
                   "vec": [
                     {
-                      "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                      "bytes": "3434343434343434343434343434343434343434343434343434343434343434"
                     }
                   ]
                 }
@@ -135,7 +134,7 @@
                   "symbol": "CommitmentOwner"
                 },
                 {
-                  "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                  "bytes": "3434343434343434343434343434343434343434343434343434343434343434"
                 }
               ]
             },
@@ -155,7 +154,7 @@
                       "symbol": "CommitmentOwner"
                     },
                     {
-                      "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                      "bytes": "3434343434343434343434343434343434343434343434343434343434343434"
                     }
                   ]
                 },
@@ -200,7 +199,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "bca74ab50316fc13723f64b52b20b571a0c2f77a65f6e21773fd705f9876fdc4"
+                  "bytes": "ca02a7bbd898b4cdf99e60c923abcf116f3cc8224a790f395c36953f207cf09a"
                 }
               }
             },
@@ -259,7 +258,7 @@
                         "symbol": "commitment_hash"
                       },
                       "val": {
-                        "bytes": "6949d8f4b9e525930b71ee1e4b602ebc89adeb6e7803f6c1dabd9f643fb40059"
+                        "bytes": "3434343434343434343434343434343434343434343434343434343434343434"
                       }
                     },
                     {
@@ -466,38 +465,6 @@
             "ext": "v0"
           },
           6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-            "key": "ledger_key_contract_instance",
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-                "key": "ledger_key_contract_instance",
-                "durability": "persistent",
-                "val": {
-                  "contract_instance": {
-                    "executable": {
-                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-                    },
-                    "storage": null
-                  }
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
         ]
       ],
       [

--- a/contracts/ip_registry/test_snapshots/test/tests/test_notarize_ip_timestamp_with_valid_signature.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_notarize_ip_timestamp_with_valid_signature.1.json
@@ -18,7 +18,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
+                  "bytes": "3232323232323232323232323232323232323232323232323232323232323232"
                 },
                 {
                   "u32": 0
@@ -32,21 +32,15 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "commit_ip",
+              "function_name": "set_notary_public_key",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "bytes": "1111111111111111111111111111111111111111111111111111111111111111"
-                },
-                {
-                  "u32": 0
+                  "bytes": "197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61"
                 }
               ]
             }
@@ -55,31 +49,8 @@
         }
       ]
     ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "commit_ip",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "bytes": "1212121212121212121212121212121212121212121212121212121212121212"
-                },
-                {
-                  "u32": 0
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
+    [],
+    [],
     []
   ],
   "ledger": {
@@ -163,13 +134,7 @@
                 "val": {
                   "vec": [
                     {
-                      "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
-                    },
-                    {
-                      "bytes": "1111111111111111111111111111111111111111111111111111111111111111"
-                    },
-                    {
-                      "bytes": "1212121212121212121212121212121212121212121212121212121212121212"
+                      "bytes": "3232323232323232323232323232323232323232323232323232323232323232"
                     }
                   ]
                 }
@@ -190,7 +155,7 @@
                   "symbol": "CommitmentOwner"
                 },
                 {
-                  "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
+                  "bytes": "3232323232323232323232323232323232323232323232323232323232323232"
                 }
               ]
             },
@@ -210,97 +175,7 @@
                       "symbol": "CommitmentOwner"
                     },
                     {
-                      "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          6307200
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "CommitmentOwner"
-                },
-                {
-                  "bytes": "1111111111111111111111111111111111111111111111111111111111111111"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "CommitmentOwner"
-                    },
-                    {
-                      "bytes": "1111111111111111111111111111111111111111111111111111111111111111"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          6307200
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "CommitmentOwner"
-                },
-                {
-                  "bytes": "1212121212121212121212121212121212121212121212121212121212121212"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "CommitmentOwner"
-                    },
-                    {
-                      "bytes": "1212121212121212121212121212121212121212121212121212121212121212"
+                      "bytes": "3232323232323232323232323232323232323232323232323232323232323232"
                     }
                   ]
                 },
@@ -345,7 +220,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "49123fe33eb96ec648e137640414dc361e3b86fa26c0f479d10ae5038bd07b63"
+                  "bytes": "0d6ba19b62531ccb0deb8804313eca283c69560f66f1b7b8a2c1592ae8c35c6b"
                 }
               }
             },
@@ -404,7 +279,7 @@
                         "symbol": "commitment_hash"
                       },
                       "val": {
-                        "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
+                        "bytes": "3232323232323232323232323232323232323232323232323232323232323232"
                       }
                     },
                     {
@@ -419,219 +294,9 @@
                       "key": {
                         "symbol": "notary_signature"
                       },
-                      "val": "void"
-                    },
-                    {
-                      "key": {
-                        "symbol": "owner"
-                      },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "bytes": "92baba97cd29674a5985d0af7d2461fa692498deeb6dcbefa670145ef7275f45cae0a73ed5643b1e52064de9c19ea825e72ba50db3cf14fd097a1b0aa13e7707"
                       }
-                    },
-                    {
-                      "key": {
-                        "symbol": "parent_ip_id"
-                      },
-                      "val": "void"
-                    },
-                    {
-                      "key": {
-                        "symbol": "revoked"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "timestamp"
-                      },
-                      "val": {
-                        "u64": 0
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          6307200
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "IpRecord"
-                },
-                {
-                  "u64": 2
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "IpRecord"
-                    },
-                    {
-                      "u64": 2
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "co_owners"
-                      },
-                      "val": {
-                        "vec": []
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "commitment_hash"
-                      },
-                      "val": {
-                        "bytes": "1111111111111111111111111111111111111111111111111111111111111111"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "ip_id"
-                      },
-                      "val": {
-                        "u64": 2
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "notary_signature"
-                      },
-                      "val": "void"
-                    },
-                    {
-                      "key": {
-                        "symbol": "owner"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "parent_ip_id"
-                      },
-                      "val": "void"
-                    },
-                    {
-                      "key": {
-                        "symbol": "revoked"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "timestamp"
-                      },
-                      "val": {
-                        "u64": 0
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          6307200
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "IpRecord"
-                },
-                {
-                  "u64": 3
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "IpRecord"
-                    },
-                    {
-                      "u64": 3
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "co_owners"
-                      },
-                      "val": {
-                        "vec": []
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "commitment_hash"
-                      },
-                      "val": {
-                        "bytes": "1212121212121212121212121212121212121212121212121212121212121212"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "ip_id"
-                      },
-                      "val": {
-                        "u64": 3
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "notary_signature"
-                      },
-                      "val": "void"
                     },
                     {
                       "key": {
@@ -702,7 +367,46 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "u64": 4
+                  "u64": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "NotaryPublicKey"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "NotaryPublicKey"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61"
                 }
               }
             },
@@ -750,12 +454,6 @@
                   "vec": [
                     {
                       "u64": 1
-                    },
-                    {
-                      "u64": 2
-                    },
-                    {
-                      "u64": 3
                     }
                   ]
                 }
@@ -801,6 +499,39 @@
       [
         {
           "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
@@ -820,72 +551,6 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 1033654523790656264
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 1033654523790656264
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 5541220902715666415
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
                   }
                 },
                 "durability": "temporary",

--- a/contracts/ip_registry/test_snapshots/test/tests/test_notarize_ip_timestamp_wrong_sig_length_panics.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_notarize_ip_timestamp_wrong_sig_length_panics.1.json
@@ -18,7 +18,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
+                  "bytes": "3535353535353535353535353535353535353535353535353535353535353535"
                 },
                 {
                   "u32": 0
@@ -32,46 +32,15 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "commit_ip",
+              "function_name": "set_notary_public_key",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "bytes": "1111111111111111111111111111111111111111111111111111111111111111"
-                },
-                {
-                  "u32": 0
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "commit_ip",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "bytes": "1212121212121212121212121212121212121212121212121212121212121212"
-                },
-                {
-                  "u32": 0
+                  "bytes": "9475c6cf0eda34057528d8694781ecc92ad639d7e2bd27761ed3ef74924beb07"
                 }
               ]
             }
@@ -163,13 +132,7 @@
                 "val": {
                   "vec": [
                     {
-                      "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
-                    },
-                    {
-                      "bytes": "1111111111111111111111111111111111111111111111111111111111111111"
-                    },
-                    {
-                      "bytes": "1212121212121212121212121212121212121212121212121212121212121212"
+                      "bytes": "3535353535353535353535353535353535353535353535353535353535353535"
                     }
                   ]
                 }
@@ -190,7 +153,7 @@
                   "symbol": "CommitmentOwner"
                 },
                 {
-                  "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
+                  "bytes": "3535353535353535353535353535353535353535353535353535353535353535"
                 }
               ]
             },
@@ -210,97 +173,7 @@
                       "symbol": "CommitmentOwner"
                     },
                     {
-                      "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          6307200
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "CommitmentOwner"
-                },
-                {
-                  "bytes": "1111111111111111111111111111111111111111111111111111111111111111"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "CommitmentOwner"
-                    },
-                    {
-                      "bytes": "1111111111111111111111111111111111111111111111111111111111111111"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          6307200
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "CommitmentOwner"
-                },
-                {
-                  "bytes": "1212121212121212121212121212121212121212121212121212121212121212"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "CommitmentOwner"
-                    },
-                    {
-                      "bytes": "1212121212121212121212121212121212121212121212121212121212121212"
+                      "bytes": "3535353535353535353535353535353535353535353535353535353535353535"
                     }
                   ]
                 },
@@ -345,7 +218,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "49123fe33eb96ec648e137640414dc361e3b86fa26c0f479d10ae5038bd07b63"
+                  "bytes": "b235d9133396f6aa4f6e6a6d6c6cc16bb8cd806f484918177f1d8027afd44687"
                 }
               }
             },
@@ -404,7 +277,7 @@
                         "symbol": "commitment_hash"
                       },
                       "val": {
-                        "bytes": "1010101010101010101010101010101010101010101010101010101010101010"
+                        "bytes": "3535353535353535353535353535353535353535353535353535353535353535"
                       }
                     },
                     {
@@ -413,218 +286,6 @@
                       },
                       "val": {
                         "u64": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "notary_signature"
-                      },
-                      "val": "void"
-                    },
-                    {
-                      "key": {
-                        "symbol": "owner"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "parent_ip_id"
-                      },
-                      "val": "void"
-                    },
-                    {
-                      "key": {
-                        "symbol": "revoked"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "timestamp"
-                      },
-                      "val": {
-                        "u64": 0
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          6307200
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "IpRecord"
-                },
-                {
-                  "u64": 2
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "IpRecord"
-                    },
-                    {
-                      "u64": 2
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "co_owners"
-                      },
-                      "val": {
-                        "vec": []
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "commitment_hash"
-                      },
-                      "val": {
-                        "bytes": "1111111111111111111111111111111111111111111111111111111111111111"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "ip_id"
-                      },
-                      "val": {
-                        "u64": 2
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "notary_signature"
-                      },
-                      "val": "void"
-                    },
-                    {
-                      "key": {
-                        "symbol": "owner"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "parent_ip_id"
-                      },
-                      "val": "void"
-                    },
-                    {
-                      "key": {
-                        "symbol": "revoked"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "timestamp"
-                      },
-                      "val": {
-                        "u64": 0
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          6307200
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "IpRecord"
-                },
-                {
-                  "u64": 3
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "IpRecord"
-                    },
-                    {
-                      "u64": 3
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "co_owners"
-                      },
-                      "val": {
-                        "vec": []
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "commitment_hash"
-                      },
-                      "val": {
-                        "bytes": "1212121212121212121212121212121212121212121212121212121212121212"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "ip_id"
-                      },
-                      "val": {
-                        "u64": 3
                       }
                     },
                     {
@@ -702,7 +363,46 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "u64": 4
+                  "u64": 2
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "NotaryPublicKey"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "NotaryPublicKey"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "bytes": "9475c6cf0eda34057528d8694781ecc92ad639d7e2bd27761ed3ef74924beb07"
                 }
               }
             },
@@ -750,12 +450,6 @@
                   "vec": [
                     {
                       "u64": 1
-                    },
-                    {
-                      "u64": 2
-                    },
-                    {
-                      "u64": 3
                     }
                   ]
                 }
@@ -801,6 +495,39 @@
       [
         {
           "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
@@ -820,72 +547,6 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 1033654523790656264
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 1033654523790656264
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 5541220902715666415
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
                   }
                 },
                 "durability": "temporary",

--- a/contracts/ip_registry/test_snapshots/test/tests/test_reveal_partial_valid_proof_returns_true_and_stores.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_reveal_partial_valid_proof_returns_true_and_stores.1.json
@@ -113,6 +113,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "a6a96ccb5233f068bf41343ffd5984bf8d4d7e591f1e4bdb12bda296534409b8"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -181,7 +224,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "2e4f35db41e60195e63e032a1585521434e13864966ee5449bbff6fe77946724"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_reveal_partial_wrong_blinding_returns_false.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_reveal_partial_wrong_blinding_returns_false.1.json
@@ -113,6 +113,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "5189c77d29fe5d546a045ec46986852785fea5c13ac7da9c115ff5fb6edf817c"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -181,7 +224,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "1140b574afee3cb89a4db3dc8037acfa856f5112e68a954e3ca0a908082c98ba"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_reveal_partial_wrong_partial_hash_returns_false.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_reveal_partial_wrong_partial_hash_returns_false.1.json
@@ -113,6 +113,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "96bc917d05134ba810b71de80ffafc1e302f0174b9393de8e6d6d197a68289c1"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -181,7 +224,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "d0bcaf42704ff253fc601dc2ace17e097a6621000f6d4597c9f0c6029c47916d"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_revoke_ip_emits_event.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_revoke_ip_emits_event.1.json
@@ -106,6 +106,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0909090909090909090909090909090909090909090909090909090909090909"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -174,7 +217,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "8c0cc17a04942cc4f8e0fe0b302606d3108860c126428ba2ceeb5f9ed41c2b05"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_revoke_ip_marks_record_revoked.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_revoke_ip_marks_record_revoked.1.json
@@ -108,6 +108,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0707070707070707070707070707070707070707070707070707070707070707"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -176,7 +219,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "4bb06f8e4e3a7715d201d573d0aa423762e55dabd61a2c02278fa56cc6d294e0"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_revoke_ip_requires_owner_auth.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_revoke_ip_requires_owner_auth.1.json
@@ -89,6 +89,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0909090909090909090909090909090909090909090909090909090909090909"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -157,7 +200,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "8c0cc17a04942cc4f8e0fe0b302606d3108860c126428ba2ceeb5f9ed41c2b05"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_revoke_ip_twice_panics.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_revoke_ip_twice_panics.1.json
@@ -107,6 +107,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0808080808080808080808080808080808080808080808080808080808080808"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -175,7 +218,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "2578ccf8645b2d1dc10c465eff843585970f3a7e22296a92cad55d489a272072"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_sequential_ip_ids.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_sequential_ip_ids.1.json
@@ -137,6 +137,55 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                    },
+                    {
+                      "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                    },
+                    {
+                      "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -295,7 +344,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "8a2e491356cfdb05a1d13785e0794d7cd163f91af79a146c976b1d2ac643b679"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_transfer_ip_emits_event.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_transfer_ip_emits_event.1.json
@@ -109,6 +109,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "1414141414141414141414141414141414141414141414141414141414141414"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -177,7 +220,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "f8e628cc32beb4520511268c0ef7912f1112f6fde04393577a117f92e2de4bc2"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_transfer_ip_ownership_successful.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_transfer_ip_ownership_successful.1.json
@@ -112,6 +112,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "1515151515151515151515151515151515151515151515151515151515151515"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -180,7 +223,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "c948faa4d3613332d53bac5bbbc52558685a4d3cc16ff48b14cb2f1f85a7c94b"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_transfer_ip_ownership_unauthorized_rejected.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_transfer_ip_ownership_unauthorized_rejected.1.json
@@ -89,6 +89,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "1616161616161616161616161616161616161616161616161616161616161616"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -157,7 +200,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "6f5ecb8fc873d204b6d63341061da5235d987850a6515827487607e4b3be2857"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_transfer_ip_requires_owner_auth.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_transfer_ip_requires_owner_auth.1.json
@@ -89,6 +89,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0606060606060606060606060606060606060606060606060606060606060606"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -157,7 +200,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "e802086ad6a1e16b78352ad7296d2aabd835b1b16dbe951e1135b97c68e29d81"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_transfer_ip_updates_owner_and_indexes.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_transfer_ip_updates_owner_and_indexes.1.json
@@ -112,6 +112,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0505050505050505050505050505050505050505050505050505050505050505"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -180,7 +223,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "f849d67325facf04177bc663b2dc544051831c589ef581d412f2eba44834e77c"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/test/tests/test_verify_commitment_with_invalid_secret_fails.1.json
+++ b/contracts/ip_registry/test_snapshots/test/tests/test_verify_commitment_with_invalid_secret_fails.1.json
@@ -89,6 +89,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "75dd2489677bd726c746a05929f3da15c9a8a19339fa53d6d99331d412bf920f"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -157,7 +200,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "ad3600f45c8ff9f5f6af6643df0d21ac7a4ded4bc7e9d22b80d9ea9f92d80fc9"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/tests/test_commit_ip_version_links_parent.1.json
+++ b/contracts/ip_registry/test_snapshots/tests/test_commit_ip_version_links_parent.1.json
@@ -136,6 +136,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -249,7 +292,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "52fe6094743bfd4f9be4321d98adc7e23c1ab622b0ba830e271d1ee1cbfd7850"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/tests/test_commitment_timestamp_accuracy.1.json
+++ b/contracts/ip_registry/test_snapshots/tests/test_commitment_timestamp_accuracy.1.json
@@ -88,6 +88,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -156,7 +199,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "544e62cee8033709e389e5b2755343d0d0fa8c4850215cfb6331717e80d1aea3"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/tests/test_get_ip_version_chain_multiple_versions.1.json
+++ b/contracts/ip_registry/test_snapshots/tests/test_get_ip_version_chain_multiple_versions.1.json
@@ -185,6 +185,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -343,7 +386,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "56d2617ec4deb8c5b71b3549b853c844e5ea57a8a8780711e0322a1cc84825e2"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/tests/test_get_ip_version_chain_single.1.json
+++ b/contracts/ip_registry/test_snapshots/tests/test_get_ip_version_chain_single.1.json
@@ -88,6 +88,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -156,7 +199,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "3112fa1d1185697e9239f5dc13df9d188d6a18eb4c1c578c88479b44d8a31466"
                 }
               }
             },

--- a/contracts/ip_registry/test_snapshots/tests/test_non_owner_commit_succeeds_with_mock_all_auths.1.json
+++ b/contracts/ip_registry/test_snapshots/tests/test_non_owner_commit_succeeds_with_mock_all_auths.1.json
@@ -88,6 +88,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "CommitmentHashes"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CommitmentHashes"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CommitmentOwner"
                 },
                 {
@@ -156,7 +199,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bytes": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  "bytes": "72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793"
                 }
               }
             },


### PR DESCRIPTION
feat: Implement Issues #428, #429, #430, #431 — IP Registry Enhancements                    
                                                                                              

  Closes #428                                                                                 
  Closes #429                                                                                 
  Closes #430                                                                                 
  Closes #431                                                                                 
                                                                                              
  ────────────────────────────────────────────────────────────────────────────────────────────
                                                                                              
  Overview                                                                                    
                                                                                              
  This PR implements four enhancements to the ip_registry Soroban smart contract, covering    
  timestamp notarization, rollback protection, commitment versioning, and expiration warnings.
                                                                                              
  ────────────────────────────────────────────────────────────────────────────────────────────
                                                                                              
  #428 — Add Commitment Timestamp Notarization                                                
                                                                                              
  Problem: notarize_ip_timestamp was a placeholder that accepted any signature without        
  verification, providing no real security guarantee.                                         
                                                                                              
  Changes:                                                                                    
                                                                                              
  - Added set_notary_public_key(public_key: BytesN<32>) — admin-only function to store the    
  trusted notary Ed25519 public key on-chain.                                                 
  - Replaced the placeholder notarize_ip_timestamp with real Ed25519 signature verification   
  using env.crypto().ed25519_verify(). The notary must sign the message ip_id (8 bytes BE) || 
  timestamp (8 bytes BE) with the registered private key.                                     
  - Added NotaryPublicKey storage key variant to DataKey in both lib.rs and types.rs.         
  - Added ed25519-dalek as a dev-dependency for test signing.                                 
                                                                                              
  Tests added (4):                                                                            
                                                                                              
  - test_notarize_ip_timestamp_with_valid_signature — valid Ed25519 signature is accepted and 
  stored                                                                                      
  - test_notarize_ip_timestamp_invalid_signature_panics — wrong signature panics              
  - test_notarize_ip_timestamp_no_public_key_panics — panics when no public key is configured 
  - test_notarize_ip_timestamp_wrong_sig_length_panics — panics when signature is not 64 bytes
                                                                                              
  ────────────────────────────────────────────────────────────────────────────────────────────
                                                                                              
  #429 — Implement IP Rollback Protection                                                     
                                                                                              
  Problem: update_commitment_checksum hashed an empty byte string on every call, making the   
  stored checksum meaningless and providing no real rollback protection.                      
                                                                                              
  Changes:                                                                                    
                                                                                              
  - Fixed update_commitment_checksum to append each new commitment hash to a persistent       
  CommitmentHashes list, then recompute the checksum as sha256(hash_1 || hash_2 || ... ||     
  hash_n). Called automatically on every commit_ip and batch_commit_ip.                       
  - Fixed verify_commitment_integrity to recompute the checksum from the tracked              
  CommitmentHashes list and compare it to the stored value — any tampering with the list or   
  checksum is detectable.                                                                     
  - Added CommitmentHashes storage key variant to DataKey.                                    
                                                                                              
  Tests added (2):                                                                            
                                                                                              
  - test_commitment_checksum_updated_on_commit — checksum is stored and integrity passes after
  commits                                                                                     
  - test_commitment_checksum_reflects_all_commitments — integrity check is deterministic      
  across calls                                                                                
                                                                                              
  ────────────────────────────────────────────────────────────────────────────────────────────
                                                                                              
  #430 — Add IP Commitment Versioning                                                         
                                                                                              
  Problem: While create_ip_version, commit_ip_version, get_ip_lineage, and                    
  get_ip_version_chain existed, there was no way to retrieve the direct child versions of a   
  specific IP.                                                                                
  Changes:                                                                                    
                                                                                              
  - Added get_ip_versions(ip_id: u64) -> Vec<u64> — returns the IDs of all direct child       
  versions created from the given IP via create_ip_version / commit_ip_version. Returns an    
  empty vec if no versions exist. Panics if the IP does not exist.                            
                                                                                              
  Tests added (4):                                                                            
                                                                                              
  - test_get_ip_versions_returns_direct_children — returns correct child IDs after versioning 
  - test_get_ip_versions_empty_for_no_versions — returns empty vec for unversioned IP         
  - test_get_ip_lineage_includes_root_and_versions — lineage includes root and all versions   
  - test_get_ip_version_chain_includes_all — version chain includes root and descendants      
                                                                                              
  ────────────────────────────────────────────────────────────────────────────────────────────
                                                                                              
  #431 — Implement IP Claim Expiration Warnings                                               
                                                                                              
  Problem: There was no mechanism to notify IP owners when their commitment's on-chain TTL was
  approaching expiration.                                                                     
                                                                                              
  Changes:                                                                                    
                                                                                              
  - Added check_expiration_warning(ip_id: u64, warning_threshold_ledgers: u32) -> bool —      
  estimates remaining TTL as LEDGER_BUMP minus elapsed ledgers since the commitment timestamp 
  (using elapsed_seconds / 5 as a ledger proxy at ~5s/ledger). If remaining TTL ≤             
  warning_threshold_ledgers, emits an exp_warn event (ip_id, owner, remaining_ttl) and returns
  true. Returns false if not approaching expiration. Panics if the IP does not exist.         
                                                                                              
  Tests added (4):                                                                            
                                                                                              
  - test_check_expiration_warning_not_expiring — newly committed IP with small threshold      
  returns false                                                                               
  - test_check_expiration_warning_large_threshold — threshold > LEDGER_BUMP returns true      
  - test_check_expiration_warning_nonexistent_panics — panics for non-existent IP             
  - test_check_expiration_warning_emits_event_when_expiring — exp_warn event is emitted with  
  correct topic                                                                               
                                                                                              
  ────────────────────────────────────────────────────────────────────────────────────────────
                                                                                              
  Test Results                                                                                
                                                                                              
  test result: ok. 82 passed; 0 failed; 17 ignored    