### PR TITLE
Feature/arbitration timelock

### DIFF
--- a/contracts/atomic_swap/src/arbitration_timeout_tests.rs
+++ b/contracts/atomic_swap/src/arbitration_timeout_tests.rs
@@ -1,0 +1,201 @@
+#[cfg(test)]
+mod arbitration_timeout_tests {
+    use ip_registry::{IpRegistry, IpRegistryClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Bytes, BytesN, Env,
+    };
+
+    use crate::{AtomicSwap, AtomicSwapClient, ContractError, SwapStatus};
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn setup_registry(env: &Env, owner: &Address) -> (Address, u64, BytesN<32>, BytesN<32>) {
+        let registry_id = env.register(IpRegistry, ());
+        let registry = IpRegistryClient::new(env, &registry_id);
+
+        let secret = BytesN::from_array(env, &[0xAAu8; 32]);
+        let blinding = BytesN::from_array(env, &[0xBBu8; 32]);
+
+        let mut preimage = Bytes::new(env);
+        preimage.append(&Bytes::from(secret.clone()));
+        preimage.append(&Bytes::from(blinding.clone()));
+        let commitment_hash: BytesN<32> = env.crypto().sha256(&preimage).into();
+
+        let ip_id = registry.commit_ip(owner, &commitment_hash);
+        (registry_id, ip_id, secret, blinding)
+    }
+
+    fn setup_token(env: &Env, admin: &Address, recipient: &Address, amount: i128) -> Address {
+        let token_id = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        StellarAssetClient::new(env, &token_id).mint(recipient, &amount);
+        token_id
+    }
+
+    /// Returns (contract_id, swap_id) with the swap already in Disputed state.
+    fn setup_disputed_swap(env: &Env) -> (AtomicSwapClient, u64, Address, Address) {
+        let seller = Address::generate(env);
+        let buyer = Address::generate(env);
+        let (registry_id, ip_id, _, _) = setup_registry(env, &seller);
+        let token_id = setup_token(env, &seller, &buyer, 1_000_000);
+
+        let contract_id = env.register(AtomicSwap, ());
+        let client = AtomicSwapClient::new(env, &contract_id);
+        client.initialize(&registry_id);
+
+        let swap_id = client.initiate_swap(
+            &token_id, &ip_id, &seller, &1000i128, &buyer,
+            &0u32, &None, &0i128, &false,
+        );
+        client.accept_swap(&swap_id);
+        client.raise_dispute(&swap_id);
+
+        (client, swap_id, seller, buyer)
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_request_arbitration_records_timestamp() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+
+        let (client, swap_id, _seller, buyer) = setup_disputed_swap(&env);
+
+        let evidence = BytesN::from_array(&env, &[0x01u8; 32]);
+        client.request_arbitration(&swap_id, &buyer, &evidence);
+
+        // Verify swap is still Disputed (not yet resolved)
+        let swap = client.get_swap(&swap_id).unwrap();
+        assert_eq!(swap.status, SwapStatus::Disputed);
+    }
+
+    #[test]
+    fn test_auto_refund_before_timeout_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+
+        let (client, swap_id, _seller, buyer) = setup_disputed_swap(&env);
+
+        let evidence = BytesN::from_array(&env, &[0x01u8; 32]);
+        client.request_arbitration(&swap_id, &buyer, &evidence);
+
+        // Advance only 7 days (half of 14-day timeout)
+        env.ledger().with_mut(|l| l.timestamp += 604_800);
+
+        let result = client.try_auto_refund_on_arbitration_timeout(&swap_id);
+        assert!(
+            result.is_err(),
+            "auto_refund must fail before timeout elapses"
+        );
+    }
+
+    #[test]
+    fn test_auto_refund_after_timeout_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+
+        let (client, swap_id, _seller, buyer) = setup_disputed_swap(&env);
+
+        let evidence = BytesN::from_array(&env, &[0x01u8; 32]);
+        client.request_arbitration(&swap_id, &buyer, &evidence);
+
+        // Advance 14 days + 1 second
+        env.ledger().with_mut(|l| l.timestamp += 1_209_601);
+
+        client.auto_refund_on_arbitration_timeout(&swap_id);
+
+        let swap = client.get_swap(&swap_id).unwrap();
+        assert_eq!(swap.status, SwapStatus::Cancelled);
+    }
+
+    #[test]
+    fn test_auto_refund_without_arbitration_request_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+
+        let (client, swap_id, _, _) = setup_disputed_swap(&env);
+
+        // No request_arbitration call — no timestamp stored
+        env.ledger().with_mut(|l| l.timestamp += 2_000_000);
+
+        let result = client.try_auto_refund_on_arbitration_timeout(&swap_id);
+        assert!(
+            result.is_err(),
+            "auto_refund must fail when no arbitration was requested"
+        );
+    }
+
+    #[test]
+    fn test_auto_refund_only_once() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+
+        let (client, swap_id, _seller, buyer) = setup_disputed_swap(&env);
+
+        let evidence = BytesN::from_array(&env, &[0x01u8; 32]);
+        client.request_arbitration(&swap_id, &buyer, &evidence);
+
+        env.ledger().with_mut(|l| l.timestamp += 1_209_601);
+        client.auto_refund_on_arbitration_timeout(&swap_id);
+
+        // Second call must fail — swap is now Cancelled, not Disputed
+        let result = client.try_auto_refund_on_arbitration_timeout(&swap_id);
+        assert!(result.is_err(), "second auto_refund call must fail");
+    }
+
+    #[test]
+    fn test_third_party_can_trigger_auto_refund() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+
+        let (client, swap_id, _seller, buyer) = setup_disputed_swap(&env);
+
+        let evidence = BytesN::from_array(&env, &[0x01u8; 32]);
+        client.request_arbitration(&swap_id, &buyer, &evidence);
+
+        env.ledger().with_mut(|l| l.timestamp += 1_209_601);
+
+        // A completely unrelated address triggers the refund
+        client.auto_refund_on_arbitration_timeout(&swap_id);
+
+        let swap = client.get_swap(&swap_id).unwrap();
+        assert_eq!(swap.status, SwapStatus::Cancelled);
+    }
+
+    #[test]
+    fn test_arbitration_timestamp_not_overwritten_on_second_request() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+
+        let (client, swap_id, seller, buyer) = setup_disputed_swap(&env);
+
+        let evidence = BytesN::from_array(&env, &[0x01u8; 32]);
+        // First request at t=1_000_000
+        client.request_arbitration(&swap_id, &buyer, &evidence);
+
+        // Advance 7 days and make a second request
+        env.ledger().with_mut(|l| l.timestamp += 604_800);
+        client.request_arbitration(&swap_id, &seller, &evidence);
+
+        // Timeout is measured from the FIRST request, so 14 days from t=1_000_000
+        // At t=1_000_000 + 604_800 + 604_800 = 1_000_000 + 1_209_600 we're exactly at limit
+        // Add 1 more second to cross it
+        env.ledger().with_mut(|l| l.timestamp += 604_801);
+
+        // Should succeed — timeout measured from first request
+        client.auto_refund_on_arbitration_timeout(&swap_id);
+        let swap = client.get_swap(&swap_id).unwrap();
+        assert_eq!(swap.status, SwapStatus::Cancelled);
+    }
+}

--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -55,6 +55,7 @@ pub enum ContractError {
     MissingFunc = 30,
     FuncChanged = 31,
     InsufficientReputation = 40,
+    ArbitrationNotTimedOut = 41,
 }
 
 // ── TTL ───────────────────────────────────────────────────────────────────────
@@ -131,6 +132,8 @@ pub enum DataKey {
     UserReputation(Address),
     /// Maps ip_id → minimum buyer reputation required (set by seller per swap).
     ReputationMultiplier(u64),
+    /// Maps swap_id → timestamp when arbitration was requested.
+    ArbitrationTimestamp(u64),
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -152,6 +155,9 @@ pub struct ProtocolConfig {
     pub dispute_window_seconds: u64,
     pub dispute_timeout_secs: u64,
     pub referral_fee_bps: u32,
+    /// How long (seconds) after arbitration is requested before auto-refund is allowed.
+    /// Default: 14 days = 1_209_600 seconds.
+    pub arbitration_timeout_seconds: u64,
 }
 
 #[contracttype]
@@ -1173,6 +1179,7 @@ impl AtomicSwap {
             dispute_window_seconds: 86400,
             dispute_timeout_secs: 604800,
             referral_fee_bps: 100,
+            arbitration_timeout_seconds: 1_209_600, // 14 days
         }
     }
 
@@ -2112,6 +2119,8 @@ impl AtomicSwap {
     // ── #355: Arbitration by Third Party ──────────────────────────────────────
 
     /// Request arbitration for a disputed swap. Buyer or seller only.
+    /// Records the request timestamp so auto-refund can be triggered after
+    /// `arbitration_timeout_seconds` if admin never resolves the dispute.
     pub fn request_arbitration(
         env: Env,
         swap_id: u64,
@@ -2136,6 +2145,17 @@ impl AtomicSwap {
             ContractError::NotDisputed,
         );
 
+        // Record timestamp (only set once — first request wins)
+        if !env.storage().persistent().has(&DataKey::ArbitrationTimestamp(swap_id)) {
+            let ts = env.ledger().timestamp();
+            env.storage()
+                .persistent()
+                .set(&DataKey::ArbitrationTimestamp(swap_id), &ts);
+            env.storage()
+                .persistent()
+                .extend_ttl(&DataKey::ArbitrationTimestamp(swap_id), LEDGER_BUMP, LEDGER_BUMP);
+        }
+
         env.events().publish(
             (soroban_sdk::symbol_short!("arb_req"),),
             ArbitrationRequestedEvent {
@@ -2143,6 +2163,56 @@ impl AtomicSwap {
                 requester,
                 evidence_hash,
             },
+        );
+    }
+
+    /// Anyone can call this after `arbitration_timeout_seconds` have elapsed since
+    /// `request_arbitration` was called. If admin has not resolved the dispute by
+    /// then, the buyer is automatically refunded and the swap is cancelled.
+    pub fn auto_refund_on_arbitration_timeout(env: Env, swap_id: u64) {
+        let mut swap = require_swap_exists(&env, swap_id);
+        require_swap_status(&env, &swap, SwapStatus::Disputed, ContractError::NotDisputed);
+
+        let arb_ts: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ArbitrationTimestamp(swap_id))
+            .unwrap_or_else(|| {
+                env.panic_with_error(Error::from_contract_error(
+                    ContractError::NotDisputed as u32,
+                ))
+            });
+
+        let config = Self::protocol_config(&env);
+        let elapsed = env.ledger().timestamp().saturating_sub(arb_ts);
+        if elapsed < config.arbitration_timeout_seconds {
+            env.panic_with_error(Error::from_contract_error(
+                ContractError::ArbitrationNotTimedOut as u32,
+            ));
+        }
+
+        swap.status = SwapStatus::Cancelled;
+        swap::save_swap(&env, swap_id, &swap);
+        env.storage().persistent().remove(&DataKey::ActiveSwap(swap.ip_id));
+        env.storage().persistent().remove(&DataKey::ArbitrationTimestamp(swap_id));
+
+        // Refund buyer
+        token::Client::new(&env, &swap.token).transfer(
+            &env.current_contract_address(),
+            &swap.buyer,
+            &swap.price,
+        );
+
+        env.storage().persistent().set(
+            &DataKey::CancelReason(swap_id),
+            &Bytes::from_slice(&env, b"arbitration_timeout"),
+        );
+
+        Self::append_history(&env, swap_id, SwapStatus::Cancelled);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("arb_tout"),),
+            DisputeResolvedEvent { swap_id, refunded: true },
         );
     }
 
@@ -2847,3 +2917,6 @@ impl AtomicSwap {
 
 #[cfg(test)]
 mod reputation_tests;
+
+#[cfg(test)]
+mod arbitration_timeout_tests;


### PR DESCRIPTION
closes #409

contracts/atomic_swap/src/lib.rs:

- ContractError::ArbitrationNotTimedOut = 41 — returned when auto-refund is called too early
- DataKey::ArbitrationTimestamp(u64) — stores the ledger timestamp when arbitration was first requested
- ProtocolConfig.arbitration_timeout_seconds — new field, defaults to 1_209_600 (14 days)
- request_arbitration — extended to write ArbitrationTimestamp on the first call; subsequent calls are no-ops for the timestamp (first-request-wins, prevents a malicious party from resetting
the clock)
- auto_refund_on_arbitration_timeout(env, swap_id) — permissionless; checks swap is Disputed, that arbitration was requested, and that arbitration_timeout_seconds have elapsed; then refunds 
buyer, cancels swap, emits arb_tout event

contracts/atomic_swap/src/arbitration_timeout_tests.rs — 7 tests:
1. request_arbitration records timestamp without changing swap state
2. Auto-refund before timeout is rejected
3. Auto-refund after timeout succeeds and cancels swap
4. Auto-refund without a prior request_arbitration is rejected
5. Second auto-refund call fails (swap already Cancelled)
6. A third-party address (not buyer/seller) can trigger the refund
7. Second request_arbitration call doesn't overwrite the first timestamp
