### PR TITLE
Feature/multi party reveal

### DIFF
--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -56,6 +56,9 @@ pub enum ContractError {
     FuncChanged = 31,
     InsufficientReputation = 40,
     ArbitrationNotTimedOut = 41,
+    NotAllSigned = 42,
+    AlreadySigned = 43,
+    NotARequiredSigner = 44,
 }
 
 // ── TTL ───────────────────────────────────────────────────────────────────────
@@ -134,6 +137,10 @@ pub enum DataKey {
     ReputationMultiplier(u64),
     /// Maps swap_id → timestamp when arbitration was requested.
     ArbitrationTimestamp(u64),
+    /// Maps swap_id → Vec<Address> of required co-signers for key reveal.
+    SwapSigners(u64),
+    /// Maps swap_id → Vec<Address> of signers who have already signed off.
+    SwapSignatures(u64),
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -509,6 +516,25 @@ impl AtomicSwap {
         );
 
         // Verify commitment via IP registry
+        // Guard: if this swap has required signers, all must have signed before reveal.
+        if env.storage().persistent().has(&DataKey::SwapSigners(swap_id)) {
+            let signers: Vec<Address> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::SwapSigners(swap_id))
+                .unwrap_or(Vec::new(&env));
+            let signed: Vec<Address> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::SwapSignatures(swap_id))
+                .unwrap_or(Vec::new(&env));
+            if signed.len() < signers.len() {
+                env.panic_with_error(Error::from_contract_error(
+                    ContractError::NotAllSigned as u32,
+                ));
+            }
+        }
+
         let valid = registry::verify_commitment(&env, swap.ip_id, &secret, &blinding_factor);
         if !valid {
             // #354: If insurance is enabled, mark swap as claimable before panicking.
@@ -2844,6 +2870,138 @@ impl AtomicSwap {
         );
     }
 
+    // ── Multi-party reveal (co-inventor sign-off) ─────────────────────────────
+
+    /// Initiate a swap that requires all `signers` to call `sign_swap_reveal`
+    /// before the seller can call `reveal_key`. The seller must be included in
+    /// `signers` or they can still call `reveal_key` once all signers have signed.
+    /// Returns the swap ID.
+    pub fn initiate_swap_with_signers(
+        env: Env,
+        token: Address,
+        ip_id: u64,
+        seller: Address,
+        price: i128,
+        buyer: Address,
+        signers: Vec<Address>,
+    ) -> u64 {
+        require_not_paused(&env);
+        seller.require_auth();
+        require_positive_price(&env, price);
+        registry::ensure_seller_owns_active_ip(&env, ip_id, &seller);
+        require_no_active_swap(&env, ip_id);
+
+        if signers.is_empty() {
+            env.panic_with_error(Error::from_contract_error(
+                ContractError::Unauthorized as u32,
+            ));
+        }
+
+        let id: u64 = env.storage().instance().get(&DataKey::NextId).unwrap_or(0);
+
+        let swap = SwapRecord {
+            ip_id,
+            seller: seller.clone(),
+            buyer: buyer.clone(),
+            price,
+            token: token.clone(),
+            status: SwapStatus::Pending,
+            expiry: env.ledger().timestamp() + 604800u64,
+            accept_timestamp: 0,
+            required_approvals: 0,
+            dispute_timestamp: 0,
+            referrer: None,
+            collateral_amount: 0,
+            insurance_premium: 0,
+            insurance_enabled: false,
+            escrow_agent: None,
+            quantity: 1,
+            conditions: Vec::new(&env),
+        };
+
+        env.storage().persistent().set(&DataKey::Swap(id), &swap);
+        env.storage().persistent().extend_ttl(&DataKey::Swap(id), LEDGER_BUMP, LEDGER_BUMP);
+        env.storage().persistent().set(&DataKey::ActiveSwap(ip_id), &id);
+        env.storage().persistent().extend_ttl(&DataKey::ActiveSwap(ip_id), LEDGER_BUMP, LEDGER_BUMP);
+
+        // Store required signers
+        env.storage().persistent().set(&DataKey::SwapSigners(id), &signers);
+        env.storage().persistent().extend_ttl(&DataKey::SwapSigners(id), LEDGER_BUMP, LEDGER_BUMP);
+
+        swap::append_swap_for_party(&env, &seller, &buyer, id);
+
+        let mut ip_ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::IpSwaps(ip_id))
+            .unwrap_or(Vec::new(&env));
+        ip_ids.push_back(id);
+        env.storage().persistent().set(&DataKey::IpSwaps(ip_id), &ip_ids);
+        env.storage().persistent().extend_ttl(&DataKey::IpSwaps(ip_id), LEDGER_BUMP, LEDGER_BUMP);
+
+        Self::append_history(&env, id, SwapStatus::Pending);
+        env.storage().instance().set(&DataKey::NextId, &(id + 1));
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("swap_init"),),
+            SwapInitiatedEvent { swap_id: id, ip_id, seller, buyer, price },
+        );
+
+        id
+    }
+
+    /// A required signer signs off on the key reveal for a swap.
+    /// Once all required signers have signed, `reveal_key` is unblocked.
+    pub fn sign_swap_reveal(env: Env, swap_id: u64, signer: Address) {
+        signer.require_auth();
+
+        let swap = require_swap_exists(&env, swap_id);
+        require_swap_status(&env, &swap, SwapStatus::Accepted, ContractError::NotAccepted);
+
+        let signers: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SwapSigners(swap_id))
+            .unwrap_or_else(|| {
+                env.panic_with_error(Error::from_contract_error(
+                    ContractError::Unauthorized as u32,
+                ))
+            });
+
+        // Verify signer is in the required list
+        let mut is_required = false;
+        for i in 0..signers.len() {
+            if signers.get(i).unwrap() == signer {
+                is_required = true;
+                break;
+            }
+        }
+        if !is_required {
+            env.panic_with_error(Error::from_contract_error(
+                ContractError::NotARequiredSigner as u32,
+            ));
+        }
+
+        let mut signed: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SwapSignatures(swap_id))
+            .unwrap_or(Vec::new(&env));
+
+        // Prevent duplicate signatures
+        for i in 0..signed.len() {
+            if signed.get(i).unwrap() == signer {
+                env.panic_with_error(Error::from_contract_error(
+                    ContractError::AlreadySigned as u32,
+                ));
+            }
+        }
+
+        signed.push_back(signer);
+        env.storage().persistent().set(&DataKey::SwapSignatures(swap_id), &signed);
+        env.storage().persistent().extend_ttl(&DataKey::SwapSignatures(swap_id), LEDGER_BUMP, LEDGER_BUMP);
+    }
+
     // ── Reputation ────────────────────────────────────────────────────────────
 
     /// Returns the reputation score (0–100) for an address. Defaults to 50.
@@ -2920,3 +3078,6 @@ mod reputation_tests;
 
 #[cfg(test)]
 mod arbitration_timeout_tests;
+
+#[cfg(test)]
+mod multi_signer_tests;

--- a/contracts/atomic_swap/src/multi_signer_tests.rs
+++ b/contracts/atomic_swap/src/multi_signer_tests.rs
@@ -1,0 +1,245 @@
+#[cfg(test)]
+mod multi_signer_tests {
+    use ip_registry::{IpRegistry, IpRegistryClient};
+    use soroban_sdk::{
+        testutils::Address as _,
+        token::StellarAssetClient,
+        Address, Bytes, BytesN, Env, Vec,
+    };
+
+    use crate::{AtomicSwap, AtomicSwapClient, SwapStatus};
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn setup_registry(env: &Env, owner: &Address) -> (Address, u64, BytesN<32>, BytesN<32>) {
+        let registry_id = env.register(IpRegistry, ());
+        let registry = IpRegistryClient::new(env, &registry_id);
+
+        let secret = BytesN::from_array(env, &[0xAAu8; 32]);
+        let blinding = BytesN::from_array(env, &[0xBBu8; 32]);
+
+        let mut preimage = Bytes::new(env);
+        preimage.append(&Bytes::from(secret.clone()));
+        preimage.append(&Bytes::from(blinding.clone()));
+        let commitment_hash: BytesN<32> = env.crypto().sha256(&preimage).into();
+
+        let ip_id = registry.commit_ip(owner, &commitment_hash);
+        (registry_id, ip_id, secret, blinding)
+    }
+
+    fn setup_token(env: &Env, admin: &Address, recipient: &Address, amount: i128) -> Address {
+        let token_id = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        StellarAssetClient::new(env, &token_id).mint(recipient, &amount);
+        token_id
+    }
+
+    fn setup_contract(env: &Env, registry_id: &Address) -> AtomicSwapClient {
+        let contract_id = env.register(AtomicSwap, ());
+        let client = AtomicSwapClient::new(env, &contract_id);
+        client.initialize(registry_id);
+        client
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_reveal_blocked_until_all_signers_sign() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let co_signer = Address::generate(&env);
+        let buyer = Address::generate(&env);
+
+        let (registry_id, ip_id, secret, blinding) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &seller, &buyer, 1_000_000);
+        let client = setup_contract(&env, &registry_id);
+
+        let mut signers = Vec::new(&env);
+        signers.push_back(seller.clone());
+        signers.push_back(co_signer.clone());
+
+        let swap_id = client.initiate_swap_with_signers(
+            &token_id, &ip_id, &seller, &1000i128, &buyer, &signers,
+        );
+        client.accept_swap(&swap_id);
+
+        // Only seller has signed — reveal must fail
+        client.sign_swap_reveal(&swap_id, &seller);
+        let result = client.try_reveal_key(&swap_id, &seller, &secret, &blinding);
+        assert!(result.is_err(), "reveal must fail when not all signers have signed");
+    }
+
+    #[test]
+    fn test_reveal_succeeds_after_all_signers_sign() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let co_signer = Address::generate(&env);
+        let buyer = Address::generate(&env);
+
+        let (registry_id, ip_id, secret, blinding) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &seller, &buyer, 1_000_000);
+        let client = setup_contract(&env, &registry_id);
+
+        let mut signers = Vec::new(&env);
+        signers.push_back(seller.clone());
+        signers.push_back(co_signer.clone());
+
+        let swap_id = client.initiate_swap_with_signers(
+            &token_id, &ip_id, &seller, &1000i128, &buyer, &signers,
+        );
+        client.accept_swap(&swap_id);
+
+        client.sign_swap_reveal(&swap_id, &seller);
+        client.sign_swap_reveal(&swap_id, &co_signer);
+
+        // All signed — reveal must succeed
+        client.reveal_key(&swap_id, &seller, &secret, &blinding);
+
+        let swap = client.get_swap(&swap_id).unwrap();
+        assert_eq!(swap.status, SwapStatus::Completed);
+    }
+
+    #[test]
+    fn test_non_required_signer_cannot_sign() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let co_signer = Address::generate(&env);
+        let outsider = Address::generate(&env);
+        let buyer = Address::generate(&env);
+
+        let (registry_id, ip_id, _, _) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &seller, &buyer, 1_000_000);
+        let client = setup_contract(&env, &registry_id);
+
+        let mut signers = Vec::new(&env);
+        signers.push_back(seller.clone());
+        signers.push_back(co_signer.clone());
+
+        let swap_id = client.initiate_swap_with_signers(
+            &token_id, &ip_id, &seller, &1000i128, &buyer, &signers,
+        );
+        client.accept_swap(&swap_id);
+
+        let result = client.try_sign_swap_reveal(&swap_id, &outsider);
+        assert!(result.is_err(), "outsider must not be able to sign");
+    }
+
+    #[test]
+    fn test_duplicate_signature_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let co_signer = Address::generate(&env);
+        let buyer = Address::generate(&env);
+
+        let (registry_id, ip_id, _, _) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &seller, &buyer, 1_000_000);
+        let client = setup_contract(&env, &registry_id);
+
+        let mut signers = Vec::new(&env);
+        signers.push_back(seller.clone());
+        signers.push_back(co_signer.clone());
+
+        let swap_id = client.initiate_swap_with_signers(
+            &token_id, &ip_id, &seller, &1000i128, &buyer, &signers,
+        );
+        client.accept_swap(&swap_id);
+
+        client.sign_swap_reveal(&swap_id, &seller);
+        let result = client.try_sign_swap_reveal(&swap_id, &seller);
+        assert!(result.is_err(), "duplicate signature must be rejected");
+    }
+
+    #[test]
+    fn test_three_signers_all_must_sign() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let signer2 = Address::generate(&env);
+        let signer3 = Address::generate(&env);
+        let buyer = Address::generate(&env);
+
+        let (registry_id, ip_id, secret, blinding) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &seller, &buyer, 1_000_000);
+        let client = setup_contract(&env, &registry_id);
+
+        let mut signers = Vec::new(&env);
+        signers.push_back(seller.clone());
+        signers.push_back(signer2.clone());
+        signers.push_back(signer3.clone());
+
+        let swap_id = client.initiate_swap_with_signers(
+            &token_id, &ip_id, &seller, &1000i128, &buyer, &signers,
+        );
+        client.accept_swap(&swap_id);
+
+        // Two of three signed — still blocked
+        client.sign_swap_reveal(&swap_id, &seller);
+        client.sign_swap_reveal(&swap_id, &signer2);
+        assert!(
+            client.try_reveal_key(&swap_id, &seller, &secret, &blinding).is_err(),
+            "reveal must fail with only 2 of 3 signatures"
+        );
+
+        // Third signs — now unblocked
+        client.sign_swap_reveal(&swap_id, &signer3);
+        client.reveal_key(&swap_id, &seller, &secret, &blinding);
+
+        let swap = client.get_swap(&swap_id).unwrap();
+        assert_eq!(swap.status, SwapStatus::Completed);
+    }
+
+    #[test]
+    fn test_sign_on_pending_swap_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let co_signer = Address::generate(&env);
+        let buyer = Address::generate(&env);
+
+        let (registry_id, ip_id, _, _) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &seller, &buyer, 1_000_000);
+        let client = setup_contract(&env, &registry_id);
+
+        let mut signers = Vec::new(&env);
+        signers.push_back(seller.clone());
+        signers.push_back(co_signer.clone());
+
+        let swap_id = client.initiate_swap_with_signers(
+            &token_id, &ip_id, &seller, &1000i128, &buyer, &signers,
+        );
+
+        // Swap is still Pending — sign must fail (must be Accepted first)
+        let result = client.try_sign_swap_reveal(&swap_id, &seller);
+        assert!(result.is_err(), "sign must fail on a Pending swap");
+    }
+
+    #[test]
+    fn test_empty_signers_list_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+
+        let (registry_id, ip_id, _, _) = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &seller, &buyer, 1_000_000);
+        let client = setup_contract(&env, &registry_id);
+
+        let empty_signers: Vec<Address> = Vec::new(&env);
+        let result = client.try_initiate_swap_with_signers(
+            &token_id, &ip_id, &seller, &1000i128, &buyer, &empty_signers,
+        );
+        assert!(result.is_err(), "empty signers list must be rejected");
+    }
+}


### PR DESCRIPTION
closes #410 

- ContractError::NotAllSigned = 42 — reveal blocked until all signers have signed
- ContractError::AlreadySigned = 43 — duplicate signature attempt
- ContractError::NotARequiredSigner = 44 — outsider tries to sign
- DataKey::SwapSigners(u64) — stores the Vec<Address> of required co-signers
- DataKey::SwapSignatures(u64) — stores Vec<Address> of who has already signed
- initiate_swap_with_signers(env, token, ip_id, seller, price, buyer, signers) — creates a swap with a required signer list; rejects empty lists
- sign_swap_reveal(env, swap_id, signer) — any required signer calls this on an Accepted swap; rejects outsiders and duplicates
- reveal_key — gated: if SwapSigners exists for the swap, checks SwapSignatures.len() >= SwapSigners.len() before proceeding

contracts/atomic_swap/src/multi_signer_tests.rs — 7 tests:
1. Reveal blocked when only 1 of 2 signers has signed
2. Reveal succeeds after all 2 signers sign
3. Non-required signer cannot call sign_swap_reveal
4. Duplicate signature from same signer is rejected
5. 3-of-3 flow: blocked at 2, unblocked at 3
6. sign_swap_reveal on a Pending swap is rejected (must be Accept