### PR TITLE
feat: score commitments by entropy and complexity (#335)

### DIFF
--- a/contracts/ip_registry/src/lib.rs
+++ b/contracts/ip_registry/src/lib.rs
@@ -101,6 +101,7 @@ pub enum DataKey {
     EncryptionKeyRotation(u64), // Issue #434: stores rotation history for a given ip_id
     NotaryPublicKey,        // Issue #428: stores the trusted notary Ed25519 public key (32 bytes)
     CommitmentHashes,       // Issue #429: stores Vec<BytesN<32>> of all commitment hashes for rollback protection
+    IpPowDifficulty(u64),   // stores the pow_difficulty used at commit time for strength scoring
 }
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -292,6 +293,16 @@ impl IpRegistry {
         env.storage()
             .persistent()
             .extend_ttl(&DataKey::IpRecord(id), LEDGER_BUMP, LEDGER_BUMP);
+
+        // Store pow_difficulty for strength scoring (Issue: entropy/complexity scoring)
+        env.storage()
+            .persistent()
+            .set(&DataKey::IpPowDifficulty(id), &pow_difficulty);
+        env.storage().persistent().extend_ttl(
+            &DataKey::IpPowDifficulty(id),
+            LEDGER_BUMP,
+            LEDGER_BUMP,
+        );
 
         // Append to owner index
         let mut ids: Vec<u64> = env
@@ -757,6 +768,50 @@ impl IpRegistry {
             .persistent()
             .get(&DataKey::PowDifficulty)
             .unwrap_or(4u32)
+    }
+
+    /// Returns the entropy-and-complexity strength score (0–100) for an IP commitment.
+    ///
+    /// The score combines:
+    /// - **Byte entropy**: number of unique bytes in the 32-byte commitment hash,
+    ///   scaled to 0–50 (max 32 unique bytes → 50 points).
+    /// - **PoW difficulty**: the `pow_difficulty` used at commit time, scaled to 0–50
+    ///   (each difficulty bit contributes ~1.5625 points, capped at 50).
+    ///
+    /// Weak commitments (e.g. all-same-byte hashes or zero PoW) score low; strong,
+    /// high-entropy commitments with meaningful PoW score near 100.
+    ///
+    /// # Panics
+    ///
+    /// Panics with `IpNotFound` if the IP does not exist.
+    pub fn get_ip_strength(env: Env, ip_id: u64) -> u32 {
+        let record = require_ip_exists(&env, ip_id);
+        let pow_difficulty: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::IpPowDifficulty(ip_id))
+            .unwrap_or(0u32);
+
+        let hash_bytes = record.commitment_hash.to_array();
+
+        // Count unique bytes as a proxy for byte-level entropy (0–32 unique values)
+        let mut seen = [false; 256];
+        for b in hash_bytes.iter() {
+            seen[*b as usize] = true;
+        }
+        let unique_bytes = seen.iter().filter(|&&v| v).count() as u32;
+
+        // Scale unique_bytes (0–32) to 0–50
+        let entropy_score = (unique_bytes * 50) / 32;
+
+        // Scale pow_difficulty to 0–50 (32 bits max → 50 points)
+        let pow_score = if pow_difficulty >= 32 {
+            50u32
+        } else {
+            (pow_difficulty * 50) / 32
+        };
+
+        (entropy_score + pow_score).min(100)
     }
 
     /// Returns the current protocol configuration.

--- a/contracts/ip_registry/src/test.rs
+++ b/contracts/ip_registry/src/test.rs
@@ -830,41 +830,90 @@ mod tests {
     // ── Tests for Issue #335: IP Commitment Strength Scoring ──────────────────
 
     #[test]
-    #[ignore]
-    fn test_get_ip_strength() {
+    fn test_get_ip_strength_low_entropy_low_pow() {
         let env = Env::default();
         env.mock_all_auths();
         let contract_id = env.register(crate::IpRegistry, ());
         let client = IpRegistryClient::new(&env, &contract_id);
 
         let owner = <Address as TestAddress>::generate(&env);
+        // All-same-byte hash: 1 unique byte → entropy_score = (1*50)/32 = 1
+        // pow_difficulty = 0 → pow_score = 0
+        // total = 1
         let hash = BytesN::from_array(&env, &[1u8; 32]);
-
-        let ip_id = client.commit_ip(&owner, &hash, &4u32);
+        let ip_id = client.commit_ip(&owner, &hash, &0u32);
         let strength = client.get_ip_strength(&ip_id);
-
-        // Strength should be calculated based on secret length (32) and PoW difficulty (4)
-        // Formula: min(100, (32 * 2) + (4 * 3)) = min(100, 64 + 12) = 76
-        assert_eq!(strength, 76u32);
+        assert_eq!(strength, 1u32);
     }
 
     #[test]
-    #[ignore]
-    #[ignore]
-    fn test_get_ip_strength_max_capped_at_100() {
+    fn test_get_ip_strength_high_entropy() {
         let env = Env::default();
         env.mock_all_auths();
         let contract_id = env.register(crate::IpRegistry, ());
         let client = IpRegistryClient::new(&env, &contract_id);
 
         let owner = <Address as TestAddress>::generate(&env);
-        let hash = BytesN::from_array(&env, &[1u8; 32]);
-
-        let ip_id = client.commit_ip(&owner, &hash, &20u32);
+        // 32 unique bytes → entropy_score = (32*50)/32 = 50
+        // pow_difficulty = 0 → pow_score = 0
+        // total = 50
+        let hash_bytes: [u8; 32] = core::array::from_fn(|i| i as u8);
+        let hash = BytesN::from_array(&env, &hash_bytes);
+        let ip_id = client.commit_ip(&owner, &hash, &0u32);
         let strength = client.get_ip_strength(&ip_id);
+        assert_eq!(strength, 50u32);
+    }
 
-        // Strength should be capped at 100
+    #[test]
+    fn test_get_ip_strength_max_pow() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        // 32 unique bytes → entropy_score = 50
+        // pow_difficulty = 32 → pow_score = 50
+        // total = 100
+        let hash_bytes: [u8; 32] = core::array::from_fn(|i| i as u8);
+        let hash = BytesN::from_array(&env, &hash_bytes);
+        let ip_id = client.commit_ip(&owner, &hash, &32u32);
+        let strength = client.get_ip_strength(&ip_id);
         assert_eq!(strength, 100u32);
+    }
+
+    #[test]
+    fn test_get_ip_strength_capped_at_100() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        // 32 unique bytes (50) + pow_difficulty=64 → pow_score capped at 50 → total = 100
+        let hash_bytes: [u8; 32] = core::array::from_fn(|i| i as u8);
+        let hash = BytesN::from_array(&env, &hash_bytes);
+        let ip_id = client.commit_ip(&owner, &hash, &64u32);
+        let strength = client.get_ip_strength(&ip_id);
+        assert_eq!(strength, 100u32);
+    }
+
+    #[test]
+    fn test_get_ip_strength_partial_entropy_and_pow() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        // 16 unique bytes → entropy_score = (16*50)/32 = 25
+        // pow_difficulty = 16 → pow_score = (16*50)/32 = 25
+        // total = 50
+        let hash_bytes: [u8; 32] = core::array::from_fn(|i| (i % 16) as u8);
+        let hash = BytesN::from_array(&env, &hash_bytes);
+        let ip_id = client.commit_ip(&owner, &hash, &16u32);
+        let strength = client.get_ip_strength(&ip_id);
+        assert_eq!(strength, 50u32);
     }
 
     // ── Tests for Issue #338: IP Commitment Delegation ────────────────────────

--- a/docs/commitment-scheme.md
+++ b/docs/commitment-scheme.md
@@ -171,7 +171,42 @@ fn verify_commitment(
 }
 ```
 
-## Security Considerations
+## Commitment Strength Scoring
+
+Every IP commitment is assigned a **strength score** (0–100) that reflects the entropy and complexity of the commitment hash. Weak commitments (e.g. all-same-byte hashes or zero PoW) score low; strong, high-entropy commitments with meaningful PoW score near 100.
+
+### Scoring Formula
+
+```
+entropy_score = (unique_bytes_in_hash * 50) / 32   // 0–50 points
+pow_score     = min(50, (pow_difficulty * 50) / 32) // 0–50 points
+strength      = min(100, entropy_score + pow_score)
+```
+
+| Component | Max Points | Description |
+|-----------|-----------|-------------|
+| Byte entropy | 50 | Number of unique byte values in the 32-byte commitment hash, scaled to 0–50 |
+| PoW difficulty | 50 | Leading-zero-bit difficulty used at commit time, scaled to 0–50 (32 bits = 50 pts) |
+
+### Querying Strength
+
+```rust
+let strength: u32 = registry.get_ip_strength(&ip_id);
+// Returns 0–100
+```
+
+### Practical Guidance
+
+- A SHA-256 hash of real content will have ~30–32 unique bytes → ~47–50 entropy points.
+- Using `pow_difficulty = 4` (default) adds ~6 points.
+- A typical real-world commitment scores **53–56 / 100**.
+- To reach 100, use a high-entropy hash (32 unique bytes) with `pow_difficulty ≥ 32`.
+
+### Why Entropy Matters
+
+A commitment hash derived from a real design document (via SHA-256) will have high byte entropy — the 256 possible byte values are roughly uniformly distributed. A weak hash like `[0x01; 32]` (all same byte) signals the commitment may not represent genuine IP, and scores near zero.
+
+
 
 ### Why Use a Blinding Factor?
 


### PR DESCRIPTION
closes #426
- Add IpPowDifficulty(u64) DataKey to store pow_difficulty at commit time
- Implement get_ip_strength: entropy score (unique bytes, 0-50) + PoW score (0-50)
- Replace placeholder tests with 5 precise tests covering all scoring cases
- Document scoring formula in docs/commitment-scheme.md