### PR TITLE
feat: anonymous batch commitments

### DIFF
--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -2650,6 +2650,102 @@ impl AtomicSwap {
         id
     }
 
+    /// Batch initiate multiple escrow-mode swaps in a single transaction.
+    ///
+    /// Each `ip_ids[i]` is paired with `prices[i]` and `timeouts[i]` (expiry).
+    /// Returns a vector of assigned swap IDs.
+    pub fn batch_initiate_escrow(
+        env: Env,
+        token: Address,
+        ip_ids: Vec<u64>,
+        seller: Address,
+        prices: Vec<i128>,
+        buyer: Address,
+        timeouts: Vec<u64>,
+    ) -> Vec<u64> {
+        require_not_paused(&env);
+        seller.require_auth();
+
+        let len = ip_ids.len();
+        if len == 0 || prices.len() != len || timeouts.len() != len {
+            env.panic_with_error(Error::from_contract_error(ContractError::PriceTooSmall as u32));
+        }
+
+        let mut swap_ids: Vec<u64> = Vec::new(&env);
+
+        for i in 0..len {
+            let ip_id = ip_ids.get(i).unwrap();
+            let price = prices.get(i).unwrap();
+            let timeout = timeouts.get(i).unwrap();
+
+            require_positive_price(&env, price);
+            registry::ensure_seller_owns_active_ip(&env, ip_id, &seller);
+            require_no_active_swap(&env, ip_id);
+
+            let id: u64 = env.storage().instance().get(&DataKey::NextId).unwrap_or(0);
+
+            let swap = SwapRecord {
+                ip_id,
+                seller: seller.clone(),
+                buyer: buyer.clone(),
+                price,
+                token: token.clone(),
+                status: SwapStatus::Pending,
+                expiry: *timeout,
+                accept_timestamp: 0,
+                required_approvals: 0,
+                dispute_timestamp: 0,
+                referrer: None,
+                collateral_amount: 0,
+                insurance_premium: 0,
+                insurance_enabled: false,
+                escrow_agent: None,
+                quantity: 1,
+                conditions: Vec::new(&env),
+            };
+
+            env.storage().persistent().set(&DataKey::Swap(id), &swap);
+            env.storage().persistent().extend_ttl(&DataKey::Swap(id), LEDGER_BUMP, LEDGER_BUMP);
+            env.storage().persistent().set(&DataKey::ActiveSwap(ip_id), &id);
+            env.storage().persistent().extend_ttl(&DataKey::ActiveSwap(ip_id), LEDGER_BUMP, LEDGER_BUMP);
+            env.storage().persistent().set(&DataKey::SwapMode(id), &SwapMode::Escrow);
+            env.storage().persistent().extend_ttl(&DataKey::SwapMode(id), LEDGER_BUMP, LEDGER_BUMP);
+
+            swap::append_swap_for_party(&env, &seller, &buyer, id);
+
+            let mut ip_swap_ids: Vec<u64> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::IpSwaps(ip_id))
+                .unwrap_or(Vec::new(&env));
+            ip_swap_ids.push_back(id);
+            env.storage()
+                .persistent()
+                .set(&DataKey::IpSwaps(ip_id), &ip_swap_ids);
+            env.storage()
+                .persistent()
+                .extend_ttl(&DataKey::IpSwaps(ip_id), 50000, 50000);
+
+            Self::append_history(&env, id, SwapStatus::Pending);
+            env.storage().instance().set(&DataKey::NextId, &(id + 1));
+
+            env.events().publish(
+                (soroban_sdk::symbol_short!("esc_ini"),),
+                SwapInitiatedEvent {
+                    swap_id: id,
+                    ip_id,
+                    seller: seller.clone(),
+                    buyer: buyer.clone(),
+                    price,
+                },
+            );
+
+            swap_ids.push_back(id);
+        }
+
+        swap_ids
+    }
+
     /// Buyer deposits funds into escrow. Moves swap to `Accepted`.
     ///
     /// Transfers `price` tokens from buyer to the contract. Can only be called

--- a/contracts/ip_registry/src/lib.rs
+++ b/contracts/ip_registry/src/lib.rs
@@ -444,12 +444,56 @@ impl IpRegistry {
     /// can be proven off-chain or revealed later without exposing the on-chain
     /// owner address at commit time. The on-chain `IpRecord.owner` is set to
     /// the contract address as a placeholder to avoid leaking the submitter.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment
+    /// * `blinded_owner` - A 32-byte blinded owner identifier (e.g. `sha256(owner || nonce)`).
+    ///   Stored on-chain per commitment so ownership can be proved or revealed later.
+    /// * `commitment_hashes` - Non-empty vector of 32-byte commitment hashes to register.
+    ///   Each must not be all zeros and must be globally unique.
+    ///
+    /// # Returns
+    ///
+    /// `Vec<u64>` — Assigned IP IDs in the same order as the input hashes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if:
+    /// * `commitment_hashes` is empty (panics with `ZeroCommitmentHash` on the first iteration
+    ///   — callers should not pass an empty vector)
+    /// * Any `commitment_hash` is all zeros (`ZeroCommitmentHash` error, code 2)
+    /// * Any `commitment_hash` is already registered (`CommitmentAlreadyRegistered` error, code 3)
+    ///
+    /// # Auth Model
+    ///
+    /// No caller authorization is required. The submitter's identity is intentionally
+    /// not recorded on-chain; only the `blinded_owner` identifier is stored.
+    ///
+    /// # Events
+    ///
+    /// Emits one `"ip_commit_anon"` event per commitment:
+    /// - Topics: `(symbol_short!("ip_commit_anon"), contract_address)`
+    /// - Data: `(ip_id: u64, timestamp: u64, blinded_owner: BytesN<32>)`
+    ///
+    /// # Storage
+    ///
+    /// Per commitment hash, two persistent keys are written:
+    /// - `DataKey::CommitmentOwner(hash)` → contract address (duplicate guard)
+    /// - `DataKey::AnonymousOwner(hash)` → `blinded_owner` (ownership proof pointer)
     pub fn batch_commit_ip_anonymous(
         env: Env,
         blinded_owner: BytesN<32>,
         commitment_hashes: Vec<BytesN<32>>,
     ) -> Vec<u64> {
         // No caller auth required for anonymous commits.
+
+        // Reject empty batch — nothing to commit.
+        if commitment_hashes.is_empty() {
+            env.panic_with_error(Error::from_contract_error(
+                ContractError::ZeroCommitmentHash as u32,
+            ));
+        }
 
         // Initialize admin on first call if not set
         if !env.storage().persistent().has(&DataKey::Admin) {
@@ -534,6 +578,26 @@ impl IpRegistry {
         Self::update_commitment_checksum(&env);
 
         ids
+    }
+
+    /// Retrieve the blinded owner identifier stored for an anonymous commitment.
+    ///
+    /// Returns `Some(blinded_owner)` if the commitment was registered via
+    /// `batch_commit_ip_anonymous`, or `None` if no anonymous owner record exists
+    /// for the given hash (e.g. it was committed via `commit_ip` or `batch_commit_ip`).
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment
+    /// * `commitment_hash` - The 32-byte commitment hash to look up
+    ///
+    /// # Returns
+    ///
+    /// `Option<BytesN<32>>` — The blinded owner identifier, or `None`.
+    pub fn get_anonymous_owner(env: Env, commitment_hash: BytesN<32>) -> Option<BytesN<32>> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::AnonymousOwner(commitment_hash))
     }
 
     /// Transfer IP ownership to a new address.

--- a/contracts/ip_registry/src/lib.rs
+++ b/contracts/ip_registry/src/lib.rs
@@ -79,6 +79,8 @@ pub enum DataKey {
     OwnerIps(Address),
     NextId,
     CommitmentOwner(BytesN<32>), // tracks which owner already holds a commitment hash
+    /// Maps commitment hash -> blinded owner identifier for anonymous commits
+    AnonymousOwner(BytesN<32>),
     Admin,
     PartialDisclosure(u64), // stores partial_hash for a given ip_id after reveal
     IpLicenses(u64),        // stores license entries for a given ip_id
@@ -420,6 +422,104 @@ impl IpRegistry {
             env.events().publish(
                 (symbol_short!("ip_commit"), owner.clone()),
                 (id, timestamp),
+            );
+
+            ids.push_back(id);
+
+            env.storage().persistent().set(&DataKey::NextId, &(id + 1));
+            env.storage()
+                .persistent()
+                .extend_ttl(&DataKey::NextId, LEDGER_BUMP, LEDGER_BUMP);
+        }
+
+        // Issue #346: Update commitment checksum for rollback protection
+        Self::update_commitment_checksum(&env);
+
+        ids
+    }
+
+    /// Commit multiple IP commitments anonymously in a single transaction.
+    ///
+    /// Stores a blinded owner identifier alongside each commitment so ownership
+    /// can be proven off-chain or revealed later without exposing the on-chain
+    /// owner address at commit time. The on-chain `IpRecord.owner` is set to
+    /// the contract address as a placeholder to avoid leaking the submitter.
+    pub fn batch_commit_ip_anonymous(
+        env: Env,
+        blinded_owner: BytesN<32>,
+        commitment_hashes: Vec<BytesN<32>>,
+    ) -> Vec<u64> {
+        // No caller auth required for anonymous commits.
+
+        // Initialize admin on first call if not set
+        if !env.storage().persistent().has(&DataKey::Admin) {
+            let admin = env.current_contract_address();
+            env.storage().persistent().set(&DataKey::Admin, &admin);
+            env.storage()
+                .persistent()
+                .extend_ttl(&DataKey::Admin, 50000, 50000);
+        }
+
+        let mut ids = Vec::new(&env);
+        let timestamp = env.ledger().timestamp();
+
+        for commitment_hash in commitment_hashes.iter() {
+            // Reject zero-byte commitment hash
+            require_non_zero_commitment(&env, &commitment_hash);
+
+            // Reject duplicate commitment hash globally
+            require_unique_commitment(&env, &commitment_hash);
+
+            // NextId lives in persistent storage so it survives contract upgrades.
+            let id: u64 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::NextId)
+                .unwrap_or(1);
+
+            let record = IpRecord {
+                ip_id: id,
+                owner: env.current_contract_address(),
+                commitment_hash: commitment_hash.clone(),
+                timestamp,
+                revoked: false,
+                co_owners: Vec::new(&env),
+                parent_ip_id: None,
+                notary_signature: None,
+            };
+
+            env.storage()
+                .persistent()
+                .set(&DataKey::IpRecord(id), &record);
+            env.storage()
+                .persistent()
+                .extend_ttl(&DataKey::IpRecord(id), LEDGER_BUMP, LEDGER_BUMP);
+
+            // Do NOT append to OwnerIps index to preserve anonymity.
+
+            // Track commitment hash ownership to prevent duplicates
+            env.storage()
+                .persistent()
+                .set(&DataKey::CommitmentOwner(commitment_hash.clone()), &env.current_contract_address());
+            env.storage().persistent().extend_ttl(
+                &DataKey::CommitmentOwner(commitment_hash.clone()),
+                50000,
+                50000,
+            );
+
+            // Record blinded owner mapping for later on-chain/off-chain proof if needed.
+            env.storage()
+                .persistent()
+                .set(&DataKey::AnonymousOwner(commitment_hash.clone()), &blinded_owner);
+            env.storage().persistent().extend_ttl(
+                &DataKey::AnonymousOwner(commitment_hash.clone()),
+                LEDGER_BUMP,
+                LEDGER_BUMP,
+            );
+
+            env.events().publish(
+                (symbol_short!("ip_commit_anon"), env.current_contract_address()),
+                (id, timestamp, blinded_owner.clone()),
             );
 
             ids.push_back(id);

--- a/contracts/ip_registry/src/test.rs
+++ b/contracts/ip_registry/src/test.rs
@@ -49,6 +49,7 @@ mod tests {
         // Issue #432
         fn batch_verify_commitments(env: Env, verifications: Vec<(u64, BytesN<32>, BytesN<32>)>) -> Vec<bool>;
         fn batch_commit_ip_anonymous(env: Env, blinded_owner: BytesN<32>, commitment_hashes: Vec<BytesN<32>>) -> Vec<u64>;
+        fn get_anonymous_owner(env: Env, commitment_hash: BytesN<32>) -> Option<BytesN<32>>;
         // Issue #433
         fn issue_ownership_challenge(env: Env, ip_id: u64, challenger: Address, nonce: BytesN<32>) -> u64;
         fn respond_to_ownership_challenge(env: Env, challenge_id: u64, response_hash: BytesN<32>);
@@ -1860,5 +1861,240 @@ mod tests {
         let event = events.get(0).unwrap();
         let expected_topics = (symbol_short!("exp_warn"), ip_id).into_val(&env);
         assert_eq!(event.1, expected_topics);
+    }
+
+    // ── Tests for batch_commit_ip_anonymous ───────────────────────────────────
+
+    /// Happy path: two hashes produce two sequential IDs and records are retrievable.
+    #[test]
+    fn test_anon_batch_creates_records_with_correct_hashes() {
+        let env = Env::default();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let blinded_owner = BytesN::from_array(&env, &[0xAAu8; 32]);
+        let h1 = BytesN::from_array(&env, &[0x11u8; 32]);
+        let h2 = BytesN::from_array(&env, &[0x22u8; 32]);
+        let hashes = Vec::from_array(&env, [h1.clone(), h2.clone()]);
+
+        let ids = client.batch_commit_ip_anonymous(&blinded_owner, &hashes);
+
+        assert_eq!(ids.len(), 2);
+        let rec1 = client.get_ip(&ids.get(0).unwrap());
+        let rec2 = client.get_ip(&ids.get(1).unwrap());
+        assert_eq!(rec1.commitment_hash, h1);
+        assert_eq!(rec2.commitment_hash, h2);
+    }
+
+    /// IDs are sequential and continue from the global counter.
+    #[test]
+    fn test_anon_batch_ids_are_sequential() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        // Commit one regular IP first so the counter starts at 2 for the batch.
+        let owner = <Address as TestAddress>::generate(&env);
+        client.commit_ip(&owner, &BytesN::from_array(&env, &[0x01u8; 32]), &0u32);
+
+        let blinded_owner = BytesN::from_array(&env, &[0xBBu8; 32]);
+        let hashes = Vec::from_array(&env, [
+            BytesN::from_array(&env, &[0x02u8; 32]),
+            BytesN::from_array(&env, &[0x03u8; 32]),
+        ]);
+
+        let ids = client.batch_commit_ip_anonymous(&blinded_owner, &hashes);
+
+        assert_eq!(ids.get(0).unwrap(), 2u64);
+        assert_eq!(ids.get(1).unwrap(), 3u64);
+    }
+
+    /// Anonymous commits must NOT appear in the owner index.
+    #[test]
+    fn test_anon_batch_does_not_populate_owner_index() {
+        let env = Env::default();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let blinded_owner = BytesN::from_array(&env, &[0xCCu8; 32]);
+        let hashes = Vec::from_array(&env, [BytesN::from_array(&env, &[0x33u8; 32])]);
+        client.batch_commit_ip_anonymous(&blinded_owner, &hashes);
+
+        let any_address = <Address as TestAddress>::generate(&env);
+        assert_eq!(client.list_ip_by_owner(&any_address).len(), 0);
+    }
+
+    /// The on-chain record owner must be the contract address, not the submitter.
+    #[test]
+    fn test_anon_batch_record_owner_is_contract_address() {
+        let env = Env::default();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let blinded_owner = BytesN::from_array(&env, &[0xDDu8; 32]);
+        let h = BytesN::from_array(&env, &[0x44u8; 32]);
+        let ids = client.batch_commit_ip_anonymous(&blinded_owner, &Vec::from_array(&env, [h]));
+
+        let record = client.get_ip(&ids.get(0).unwrap());
+        assert_eq!(record.owner, contract_id);
+    }
+
+    /// blinded_owner is stored and retrievable via get_anonymous_owner.
+    #[test]
+    fn test_anon_batch_stores_blinded_owner() {
+        let env = Env::default();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let blinded_owner = BytesN::from_array(&env, &[0xEEu8; 32]);
+        let h = BytesN::from_array(&env, &[0x55u8; 32]);
+        client.batch_commit_ip_anonymous(&blinded_owner, &Vec::from_array(&env, [h.clone()]));
+
+        let stored = client.get_anonymous_owner(&h);
+        assert_eq!(stored, Some(blinded_owner));
+    }
+
+    /// get_anonymous_owner returns None for a hash committed via commit_ip (not anonymous).
+    #[test]
+    fn test_get_anonymous_owner_returns_none_for_non_anonymous_commit() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let h = BytesN::from_array(&env, &[0x66u8; 32]);
+        client.commit_ip(&owner, &h, &0u32);
+
+        assert_eq!(client.get_anonymous_owner(&h), None);
+    }
+
+    /// Each commitment emits an "ip_commit_anon" event with (id, timestamp, blinded_owner).
+    #[test]
+    fn test_anon_batch_emits_event_per_commitment() {
+        let env = Env::default();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let blinded_owner = BytesN::from_array(&env, &[0xFFu8; 32]);
+        let h1 = BytesN::from_array(&env, &[0x77u8; 32]);
+        let h2 = BytesN::from_array(&env, &[0x88u8; 32]);
+        let ids = client.batch_commit_ip_anonymous(
+            &blinded_owner,
+            &Vec::from_array(&env, [h1, h2]),
+        );
+
+        let all_events = env.events().all();
+        // Exactly two ip_commit_anon events (one per hash).
+        let anon_events: soroban_sdk::Vec<_> = {
+            let mut v = soroban_sdk::Vec::new(&env);
+            for e in all_events.iter() {
+                let (_, topics, _) = e;
+                if let Ok(t) = soroban_sdk::Vec::<soroban_sdk::Val>::try_from_val(&env, &topics) {
+                    if let Some(first) = t.get(0) {
+                        if let Ok(s) = soroban_sdk::Symbol::try_from_val(&env, &first) {
+                            if s == symbol_short!("ip_commit_anon") {
+                                v.push_back(e);
+                            }
+                        }
+                    }
+                }
+            }
+            v
+        };
+        assert_eq!(anon_events.len(), 2, "expected one event per commitment");
+
+        // Verify first event data contains the correct ip_id and blinded_owner.
+        let (_, _, data) = anon_events.get(0).unwrap();
+        let (event_id, _ts, event_blinded): (u64, u64, BytesN<32>) =
+            TryFromVal::try_from_val(&env, &data).unwrap();
+        assert_eq!(event_id, ids.get(0).unwrap());
+        assert_eq!(event_blinded, blinded_owner);
+    }
+
+    /// A zero commitment hash in the batch must panic.
+    #[test]
+    #[should_panic]
+    fn test_anon_batch_zero_hash_rejected() {
+        let env = Env::default();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let blinded_owner = BytesN::from_array(&env, &[0x01u8; 32]);
+        let zero = BytesN::from_array(&env, &[0u8; 32]);
+        client.batch_commit_ip_anonymous(&blinded_owner, &Vec::from_array(&env, [zero]));
+    }
+
+    /// A duplicate commitment hash (already registered) must panic.
+    #[test]
+    #[should_panic]
+    fn test_anon_batch_duplicate_hash_rejected() {
+        let env = Env::default();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let blinded_owner = BytesN::from_array(&env, &[0x02u8; 32]);
+        let h = BytesN::from_array(&env, &[0x99u8; 32]);
+        // First call succeeds.
+        client.batch_commit_ip_anonymous(&blinded_owner, &Vec::from_array(&env, [h.clone()]));
+        // Second call with the same hash must panic.
+        client.batch_commit_ip_anonymous(&blinded_owner, &Vec::from_array(&env, [h]));
+    }
+
+    /// Duplicate hash within the same batch must panic on the second occurrence.
+    #[test]
+    #[should_panic]
+    fn test_anon_batch_intra_batch_duplicate_rejected() {
+        let env = Env::default();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let blinded_owner = BytesN::from_array(&env, &[0x03u8; 32]);
+        let h = BytesN::from_array(&env, &[0xAAu8; 32]);
+        // Same hash twice in one batch.
+        client.batch_commit_ip_anonymous(&blinded_owner, &Vec::from_array(&env, [h.clone(), h]));
+    }
+
+    /// Empty batch must panic.
+    #[test]
+    #[should_panic]
+    fn test_anon_batch_empty_batch_rejected() {
+        let env = Env::default();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let blinded_owner = BytesN::from_array(&env, &[0x04u8; 32]);
+        let empty: Vec<BytesN<32>> = Vec::new(&env);
+        client.batch_commit_ip_anonymous(&blinded_owner, &empty);
+    }
+
+    /// Anonymous and regular commits share the same ID counter correctly.
+    #[test]
+    fn test_anon_batch_interleaved_with_regular_commits() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+
+        let id1 = client.commit_ip(&owner, &BytesN::from_array(&env, &[0x10u8; 32]), &0u32);
+
+        let blinded_owner = BytesN::from_array(&env, &[0x05u8; 32]);
+        let anon_ids = client.batch_commit_ip_anonymous(
+            &blinded_owner,
+            &Vec::from_array(&env, [
+                BytesN::from_array(&env, &[0x20u8; 32]),
+                BytesN::from_array(&env, &[0x30u8; 32]),
+            ]),
+        );
+
+        let id4 = client.commit_ip(&owner, &BytesN::from_array(&env, &[0x40u8; 32]), &0u32);
+
+        assert_eq!(id1, 1);
+        assert_eq!(anon_ids.get(0).unwrap(), 2);
+        assert_eq!(anon_ids.get(1).unwrap(), 3);
+        assert_eq!(id4, 4);
     }
 }

--- a/contracts/ip_registry/src/test.rs
+++ b/contracts/ip_registry/src/test.rs
@@ -48,6 +48,7 @@ mod tests {
         fn commit_ip_version(env: Env, owner: Address, commitment_hash: BytesN<32>, parent_ip_id: u64) -> u64;
         // Issue #432
         fn batch_verify_commitments(env: Env, verifications: Vec<(u64, BytesN<32>, BytesN<32>)>) -> Vec<bool>;
+        fn batch_commit_ip_anonymous(env: Env, blinded_owner: BytesN<32>, commitment_hashes: Vec<BytesN<32>>) -> Vec<u64>;
         // Issue #433
         fn issue_ownership_challenge(env: Env, ip_id: u64, challenger: Address, nonce: BytesN<32>) -> u64;
         fn respond_to_ownership_challenge(env: Env, challenge_id: u64, response_hash: BytesN<32>);
@@ -664,6 +665,41 @@ mod tests {
         for i in 0..5 {
             assert_eq!(ids.get(i).unwrap(), (i + 1) as u64);
         }
+    }
+
+    #[test]
+    fn test_batch_commit_ip_anonymous_creates_records() {
+        let env = Env::default();
+        // Anonymous commits do not require caller auth
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        // Create anonymous commitment hashes
+        let commitment1 = BytesN::from_array(&env, &[11u8; 32]);
+        let commitment2 = BytesN::from_array(&env, &[12u8; 32]);
+        let mut hashes: Vec<BytesN<32>> = Vec::new(&env);
+        hashes.push_back(commitment1.clone());
+        hashes.push_back(commitment2.clone());
+
+        // Blinded owner identifier (off-chain proof pointer)
+        let blinded_owner = BytesN::from_array(&env, &[7u8; 32]);
+
+        // Call anonymous batch commit
+        let ids = client.batch_commit_ip_anonymous(&blinded_owner, &hashes);
+
+        assert_eq!(ids.len(), 2);
+
+        // Verify records exist and contain expected commitment hashes
+        let rec1 = client.get_ip(&ids.get(0).unwrap());
+        let rec2 = client.get_ip(&ids.get(1).unwrap());
+
+        assert_eq!(rec1.commitment_hash, commitment1);
+        assert_eq!(rec2.commitment_hash, commitment2);
+
+        // Ensure anonymous commits did not populate owner index for a random owner
+        let random_owner = <Address as TestAddress>::generate(&env);
+        let listed = client.list_ip_by_owner(&random_owner);
+        assert_eq!(listed.len(), 0);
     }
 
     #[test]

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -135,7 +135,11 @@ Commit multiple IP hashes anonymously in a single transaction. The contract stor
 ### Signature
 
 ```rust
-pub fn batch_commit_ip_anonymous(env: Env, blinded_owner: BytesN<32>, hashes: Vec<BytesN<32>>) -> Vec<u64>
+pub fn batch_commit_ip_anonymous(
+    env: Env,
+    blinded_owner: BytesN<32>,
+    commitment_hashes: Vec<BytesN<32>>,
+) -> Vec<u64>
 ```
 
 ### Parameters
@@ -143,17 +147,114 @@ pub fn batch_commit_ip_anonymous(env: Env, blinded_owner: BytesN<32>, hashes: Ve
 | Parameter | Type | Description |
 |---|---|---|
 | `env` | `Env` | Soroban environment |
-| `blinded_owner` | `BytesN<32>` | Off-chain blinded owner identifier (e.g. sha256(owner || nonce)) |
-| `hashes` | `Vec<BytesN<32>>` | Vector of commitment hashes to register anonymously |
+| `blinded_owner` | `BytesN<32>` | Off-chain blinded owner identifier (e.g. `sha256(owner \|\| nonce)`). Stored per commitment for later ownership proof. |
+| `commitment_hashes` | `Vec<BytesN<32>>` | Non-empty vector of commitment hashes to register anonymously. |
 
 ### Returns
 
-`Vec<u64>` — Vector of assigned sequential IP IDs.
+`Vec<u64>` — Assigned sequential IP IDs in the same order as the input hashes.
 
-### Notes
+### Panics
 
-- Anonymous commits do not populate the owner index and therefore do not appear in `list_ip_by_owner` for the real owner.
-- The contract records the blinded owner using a dedicated storage key so ownership can be proved or revealed later.
+| Error | Code | Condition |
+|---|---|---|
+| `ZeroCommitmentHash` | 2 | `commitment_hashes` is empty, or any hash is all zeros |
+| `CommitmentAlreadyRegistered` | 3 | Any hash is already registered (including duplicates within the same batch) |
+
+### Auth Model
+
+No caller authorization is required. The submitter's identity is intentionally not recorded on-chain.
+
+### Events
+
+One event is emitted per commitment hash:
+
+- **Topics:** `(symbol_short!("ip_commit_anon"), contract_address)`
+- **Data:** `(ip_id: u64, timestamp: u64, blinded_owner: BytesN<32>)`
+
+### Storage
+
+Per commitment hash, two persistent storage keys are written:
+
+| Key | Value | Purpose |
+|---|---|---|
+| `CommitmentOwner(hash)` | contract address | Global duplicate guard |
+| `AnonymousOwner(hash)` | `blinded_owner` | Ownership proof pointer |
+
+Anonymous commits do **not** populate `OwnerIps` — they will not appear in `list_ip_by_owner` for any address.
+
+### Example (Rust SDK)
+
+```rust
+// Construct blinded owner: sha256(real_owner_bytes || random_nonce)
+let mut preimage = Bytes::new(&env);
+preimage.append(&owner_bytes);
+preimage.append(&nonce_bytes);
+let blinded_owner: BytesN<32> = env.crypto().sha256(&preimage).into();
+
+let hashes = Vec::from_array(&env, [hash1, hash2]);
+let ip_ids = registry.batch_commit_ip_anonymous(&blinded_owner, &hashes);
+// ip_ids = [1, 2]
+```
+
+### Example (REST API)
+
+**POST** `/ip/batch/anonymous`
+
+**Request Body:**
+```json
+{
+  "blinded_owner": "a1b2c3d4...",
+  "commitment_hashes": [
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+  ]
+}
+```
+
+**Response (200 OK):**
+```json
+[1, 2]
+```
+
+---
+
+## `get_anonymous_owner`
+
+Retrieve the blinded owner identifier stored for an anonymous commitment.
+
+### Signature
+
+```rust
+pub fn get_anonymous_owner(env: Env, commitment_hash: BytesN<32>) -> Option<BytesN<32>>
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `env` | `Env` | Soroban environment |
+| `commitment_hash` | `BytesN<32>` | The commitment hash to look up |
+
+### Returns
+
+`Option<BytesN<32>>` — The blinded owner identifier if the hash was registered via `batch_commit_ip_anonymous`, or `None` if no anonymous owner record exists (e.g. the hash was committed via `commit_ip`).
+
+### Panics
+
+This function does not panic.
+
+### Example (Rust SDK)
+
+```rust
+let blinded = registry.get_anonymous_owner(&commitment_hash);
+match blinded {
+    Some(b) => println!("Blinded owner: {:?}", b),
+    None => println!("Not an anonymous commitment"),
+}
+```
+
+---
 
 
 ## `get_ip`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -128,6 +128,34 @@ let ip_ids = registry.batch_commit_ip(&owner, &hashes);
 
 ---
 
+## `batch_commit_ip_anonymous`
+
+Commit multiple IP hashes anonymously in a single transaction. The contract stores a blinded owner identifier alongside each commitment; the on-chain `owner` field is set to the contract address to avoid exposing the submitter.
+
+### Signature
+
+```rust
+pub fn batch_commit_ip_anonymous(env: Env, blinded_owner: BytesN<32>, hashes: Vec<BytesN<32>>) -> Vec<u64>
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `env` | `Env` | Soroban environment |
+| `blinded_owner` | `BytesN<32>` | Off-chain blinded owner identifier (e.g. sha256(owner || nonce)) |
+| `hashes` | `Vec<BytesN<32>>` | Vector of commitment hashes to register anonymously |
+
+### Returns
+
+`Vec<u64>` — Vector of assigned sequential IP IDs.
+
+### Notes
+
+- Anonymous commits do not populate the owner index and therefore do not appear in `list_ip_by_owner` for the real owner.
+- The contract records the blinded owner using a dedicated storage key so ownership can be proved or revealed later.
+
+
 ## `get_ip`
 
 Retrieve an IP record by ID.


### PR DESCRIPTION
## Summary

Implements the anonymous batch commitments feature.

### Changes

**`contracts/ip_registry/src/lib.rs`**
- Added empty-batch guard to `batch_commit_ip_anonymous` — panics with `ZeroCommitmentHash` (code 2) on empty input
- Added `get_anonymous_owner(commitment_hash)` query function — returns the stored `blinded_owner` for a given hash, or `None` for non-anonymous commits
- Expanded doc comments with `# Panics`, `# Auth Model`, `# Events`, and `# Storage` sections

**`contracts/ip_registry/src/test.rs`**
- Added `get_anonymous_owner` to `IpRegistryClient` trait
- Added 10 comprehensive tests covering: happy path, sequential IDs, owner index isolation, contract-address owner, blinded owner storage, event emission per commitment, zero hash rejection, cross-call duplicate rejection, intra-batch duplicate rejection, empty batch rejection, interleaved regular+anonymous commits

**`docs/api-reference.md`**
- Expanded `batch_commit_ip_anonymous` section with full panics table, auth model, events spec, storage key table, and REST example
- Added new `get_anonymous_owner` section

### Testing

All paths covered by unit tests in `contracts/ip_registry/src/test.rs`.