### PR TITLE
Feature/tiered ip access control

### DIFF
--- a/contracts/ip_registry/src/lib.rs
+++ b/contracts/ip_registry/src/lib.rs
@@ -1606,13 +1606,23 @@ impl IpRegistry {
 
     // ── Issue #344: Tiered Access Control ──────────────────────────────────────
 
-    /// Grant access to an IP for a third party. Owner-only.
-    /// access_level: 0 = none, 1 = read-only, 2 = read-write
+    /// Grant tiered access to an IP for a third party. Owner-only.
+    ///
+    /// Access tiers are hierarchical — a higher tier implies all lower tiers:
+    /// - `1` = **view**: read IP metadata
+    /// - `2` = **verify**: view + verify the commitment
+    /// - `3` = **transfer**: view + verify + initiate transfer
+    ///
+    /// Granting to an address that already has a grant updates the level.
+    ///
+    /// # Panics
+    ///
+    /// Panics with `Unauthorized` if `access_level` is 0 or > 3, or if caller is not the owner.
     pub fn grant_ip_access(env: Env, ip_id: u64, grantee: Address, access_level: u32) {
         let record = require_ip_exists(&env, ip_id);
         record.owner.require_auth();
 
-        if access_level > 2 {
+        if access_level < 1 || access_level > 3 {
             env.panic_with_error(Error::from_contract_error(ContractError::Unauthorized as u32));
         }
 
@@ -1631,7 +1641,7 @@ impl IpRegistry {
             }
         }
         if !found {
-            grants.push_back(IpAccessGrant { grantee, access_level });
+            grants.push_back(IpAccessGrant { grantee: grantee.clone(), access_level });
         }
 
         env.storage()
@@ -1642,9 +1652,15 @@ impl IpRegistry {
             LEDGER_BUMP,
             LEDGER_BUMP,
         );
+
+        env.events().publish(
+            (symbol_short!("ac_grant"), ip_id),
+            (grantee, access_level),
+        );
     }
 
     /// Revoke access to an IP from a third party. Owner-only.
+    /// No-op if the grantee has no grant.
     pub fn revoke_ip_access(env: Env, ip_id: u64, grantee: Address) {
         let record = require_ip_exists(&env, ip_id);
         record.owner.require_auth();
@@ -1665,6 +1681,11 @@ impl IpRegistry {
                 LEDGER_BUMP,
                 LEDGER_BUMP,
             );
+
+            env.events().publish(
+                (symbol_short!("ac_revoke"), ip_id),
+                grantee,
+            );
         }
     }
 
@@ -1675,6 +1696,31 @@ impl IpRegistry {
             .persistent()
             .get(&DataKey::IpAccessGrants(ip_id))
             .unwrap_or(Vec::new(&env))
+    }
+
+    /// Check whether `grantee` has at least `required_level` access to `ip_id`.
+    ///
+    /// The owner always has full access (level 3). Tiers are hierarchical:
+    /// a grantee with level 3 satisfies a check for level 1 or 2.
+    ///
+    /// Returns `true` if access is granted, `false` otherwise.
+    pub fn check_ip_access(env: Env, ip_id: u64, grantee: Address, required_level: u32) -> bool {
+        let record = require_ip_exists(&env, ip_id);
+        // Owner always has full access
+        if grantee == record.owner {
+            return true;
+        }
+        let grants: Vec<IpAccessGrant> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::IpAccessGrants(ip_id))
+            .unwrap_or(Vec::new(&env));
+        for grant in grants.iter() {
+            if grant.grantee == grantee {
+                return grant.access_level >= required_level;
+            }
+        }
+        false
     }
 
     // ── Issue #345 / #428: Timestamp Notarization ──────────────────────────────

--- a/contracts/ip_registry/src/test.rs
+++ b/contracts/ip_registry/src/test.rs
@@ -68,6 +68,10 @@ mod tests {
         fn get_ip_lineage(env: Env, ip_id: u64) -> Vec<u64>;
         fn get_ip_version_chain(env: Env, ip_id: u64) -> Vec<u64>;
         fn check_expiration_warning(env: Env, ip_id: u64, warning_threshold_ledgers: u32) -> bool;
+        fn grant_ip_access(env: Env, ip_id: u64, grantee: Address, access_level: u32);
+        fn revoke_ip_access(env: Env, ip_id: u64, grantee: Address);
+        fn get_ip_access_grants(env: Env, ip_id: u64) -> Vec<crate::IpAccessGrant>;
+        fn check_ip_access(env: Env, ip_id: u64, grantee: Address, required_level: u32) -> bool;
     }
 
     #[test]
@@ -1873,5 +1877,216 @@ mod tests {
         let event = events.get(0).unwrap();
         let expected_topics = (symbol_short!("exp_warn"), ip_id).into_val(&env);
         assert_eq!(event.1, expected_topics);
+    }
+
+    // ── Tests for Tiered Access Control ───────────────────────────────────────
+
+    fn setup_ip(env: &Env, client: &IpRegistryClient, seed: u8) -> (Address, u64) {
+        let owner = <Address as TestAddress>::generate(env);
+        let hash = BytesN::from_array(env, &[seed; 32]);
+        let ip_id = client.commit_ip(&owner, &hash, &0u32);
+        (owner, ip_id)
+    }
+
+    #[test]
+    fn test_grant_view_access_and_check() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+        let (_, ip_id) = setup_ip(&env, &client, 10);
+        let grantee = <Address as TestAddress>::generate(&env);
+
+        client.grant_ip_access(&ip_id, &grantee, &1u32);
+
+        assert!(client.check_ip_access(&ip_id, &grantee, &1u32), "view access granted");
+        assert!(!client.check_ip_access(&ip_id, &grantee, &2u32), "verify not granted");
+        assert!(!client.check_ip_access(&ip_id, &grantee, &3u32), "transfer not granted");
+    }
+
+    #[test]
+    fn test_grant_verify_access_implies_view() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+        let (_, ip_id) = setup_ip(&env, &client, 11);
+        let grantee = <Address as TestAddress>::generate(&env);
+
+        client.grant_ip_access(&ip_id, &grantee, &2u32);
+
+        assert!(client.check_ip_access(&ip_id, &grantee, &1u32), "verify implies view");
+        assert!(client.check_ip_access(&ip_id, &grantee, &2u32), "verify access granted");
+        assert!(!client.check_ip_access(&ip_id, &grantee, &3u32), "transfer not granted");
+    }
+
+    #[test]
+    fn test_grant_transfer_access_implies_all() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+        let (_, ip_id) = setup_ip(&env, &client, 12);
+        let grantee = <Address as TestAddress>::generate(&env);
+
+        client.grant_ip_access(&ip_id, &grantee, &3u32);
+
+        assert!(client.check_ip_access(&ip_id, &grantee, &1u32));
+        assert!(client.check_ip_access(&ip_id, &grantee, &2u32));
+        assert!(client.check_ip_access(&ip_id, &grantee, &3u32));
+    }
+
+    #[test]
+    fn test_owner_always_has_full_access() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+        let (owner, ip_id) = setup_ip(&env, &client, 13);
+
+        assert!(client.check_ip_access(&ip_id, &owner, &1u32));
+        assert!(client.check_ip_access(&ip_id, &owner, &2u32));
+        assert!(client.check_ip_access(&ip_id, &owner, &3u32));
+    }
+
+    #[test]
+    fn test_ungranteed_address_has_no_access() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+        let (_, ip_id) = setup_ip(&env, &client, 14);
+        let stranger = <Address as TestAddress>::generate(&env);
+
+        assert!(!client.check_ip_access(&ip_id, &stranger, &1u32));
+    }
+
+    #[test]
+    fn test_revoke_removes_access() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+        let (_, ip_id) = setup_ip(&env, &client, 15);
+        let grantee = <Address as TestAddress>::generate(&env);
+
+        client.grant_ip_access(&ip_id, &grantee, &2u32);
+        assert!(client.check_ip_access(&ip_id, &grantee, &2u32));
+
+        client.revoke_ip_access(&ip_id, &grantee);
+        assert!(!client.check_ip_access(&ip_id, &grantee, &1u32), "access removed after revoke");
+    }
+
+    #[test]
+    fn test_upgrade_grant_level() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+        let (_, ip_id) = setup_ip(&env, &client, 16);
+        let grantee = <Address as TestAddress>::generate(&env);
+
+        client.grant_ip_access(&ip_id, &grantee, &1u32);
+        client.grant_ip_access(&ip_id, &grantee, &3u32); // upgrade
+
+        let grants = client.get_ip_access_grants(&ip_id);
+        assert_eq!(grants.len(), 1, "only one grant entry per grantee");
+        assert_eq!(grants.get(0).unwrap().access_level, 3u32);
+    }
+
+    #[test]
+    fn test_multiple_grantees() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+        let (_, ip_id) = setup_ip(&env, &client, 17);
+        let viewer = <Address as TestAddress>::generate(&env);
+        let verifier = <Address as TestAddress>::generate(&env);
+        let transferrer = <Address as TestAddress>::generate(&env);
+
+        client.grant_ip_access(&ip_id, &viewer, &1u32);
+        client.grant_ip_access(&ip_id, &verifier, &2u32);
+        client.grant_ip_access(&ip_id, &transferrer, &3u32);
+
+        let grants = client.get_ip_access_grants(&ip_id);
+        assert_eq!(grants.len(), 3);
+        assert!(client.check_ip_access(&ip_id, &viewer, &1u32));
+        assert!(!client.check_ip_access(&ip_id, &viewer, &2u32));
+        assert!(client.check_ip_access(&ip_id, &verifier, &2u32));
+        assert!(client.check_ip_access(&ip_id, &transferrer, &3u32));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_grant_invalid_level_zero_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+        let (_, ip_id) = setup_ip(&env, &client, 18);
+        let grantee = <Address as TestAddress>::generate(&env);
+        client.grant_ip_access(&ip_id, &grantee, &0u32);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_grant_invalid_level_four_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+        let (_, ip_id) = setup_ip(&env, &client, 19);
+        let grantee = <Address as TestAddress>::generate(&env);
+        client.grant_ip_access(&ip_id, &grantee, &4u32);
+    }
+
+    #[test]
+    fn test_revoke_nonexistent_grant_is_noop() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+        let (_, ip_id) = setup_ip(&env, &client, 20);
+        let stranger = <Address as TestAddress>::generate(&env);
+        // Should not panic
+        client.revoke_ip_access(&ip_id, &stranger);
+    }
+
+    #[test]
+    fn test_grant_emits_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+        let (_, ip_id) = setup_ip(&env, &client, 21);
+        let grantee = <Address as TestAddress>::generate(&env);
+
+        let _ = env.events().all();
+        client.grant_ip_access(&ip_id, &grantee, &2u32);
+
+        let events = env.events().all();
+        let last = events.last().unwrap();
+        let expected_topics = (symbol_short!("ac_grant"), ip_id).into_val(&env);
+        assert_eq!(last.1, expected_topics);
+    }
+
+    #[test]
+    fn test_revoke_emits_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+        let (_, ip_id) = setup_ip(&env, &client, 22);
+        let grantee = <Address as TestAddress>::generate(&env);
+
+        client.grant_ip_access(&ip_id, &grantee, &1u32);
+        let _ = env.events().all();
+        client.revoke_ip_access(&ip_id, &grantee);
+
+        let events = env.events().all();
+        let last = events.last().unwrap();
+        let expected_topics = (symbol_short!("ac_revoke"), ip_id).into_val(&env);
+        assert_eq!(last.1, expected_topics);
     }
 }

--- a/contracts/ip_registry/src/types.rs
+++ b/contracts/ip_registry/src/types.rs
@@ -14,11 +14,17 @@ pub const TRANSFER_TOPIC: Symbol = soroban_sdk::symbol_short!("ip_xfer");
 
 // ── Access Control ────────────────────────────────────────────────────────────
 
+/// Access tier constants for tiered IP access control.
+/// Tiers are hierarchical: transfer implies verify, verify implies view.
+pub const ACCESS_VIEW: u32 = 1;     // Can read IP metadata
+pub const ACCESS_VERIFY: u32 = 2;   // Can verify the commitment (view + verify)
+pub const ACCESS_TRANSFER: u32 = 3; // Can initiate transfer (view + verify + transfer)
+
 #[contracttype]
 #[derive(Clone)]
 pub struct IpAccessGrant {
     pub grantee: Address,
-    pub access_level: u32, // 0 = none, 1 = read-only, 2 = read-write
+    pub access_level: u32, // 1 = view, 2 = verify, 3 = transfer
 }
 
 // ── Storage Keys ────────────────────────────────────────────────────────────

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -510,3 +510,90 @@ See [TTL_MANAGEMENT.md](../TTL_MANAGEMENT.md) for details.
 - [Commitment Scheme](commitment-scheme.md) — How to construct valid commitment hashes
 - [Atomic Swap Flow](atomic-swap.md) — How to sell IP using atomic swaps
 - [Security Considerations](security.md) — Best practices for secret management
+
+---
+
+## Tiered Access Control
+
+IP owners can grant other addresses tiered read/verify/transfer access without transferring ownership.
+
+### Access Tiers
+
+| Level | Name | Permissions |
+|---|---|---|
+| `1` | **view** | Read IP metadata |
+| `2` | **verify** | View + verify the commitment |
+| `3` | **transfer** | View + verify + initiate transfer |
+
+Tiers are hierarchical: a grantee with level 3 satisfies checks for levels 1 and 2. The owner always has full access (level 3) regardless of grants.
+
+---
+
+### `grant_ip_access`
+
+Grant tiered access to an IP for a third party. Owner-only. Granting to an address that already has a grant updates the level.
+
+```rust
+pub fn grant_ip_access(env: Env, ip_id: u64, grantee: Address, access_level: u32)
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `ip_id` | `u64` | The IP to grant access to |
+| `grantee` | `Address` | The address receiving access |
+| `access_level` | `u32` | `1` = view, `2` = verify, `3` = transfer |
+
+**Panics:** `Unauthorized` (6) if `access_level` is 0 or > 3, or caller is not the owner.
+
+**Event:** `(symbol_short!("ac_grant"), ip_id)` → `(grantee, access_level)`
+
+```rust
+// Grant verify access to a partner
+registry.grant_ip_access(&ip_id, &partner, &2u32);
+```
+
+---
+
+### `revoke_ip_access`
+
+Revoke access from a grantee. Owner-only. No-op if the grantee has no grant.
+
+```rust
+pub fn revoke_ip_access(env: Env, ip_id: u64, grantee: Address)
+```
+
+**Event:** `(symbol_short!("ac_revoke"), ip_id)` → `grantee`
+
+```rust
+registry.revoke_ip_access(&ip_id, &partner);
+```
+
+---
+
+### `check_ip_access`
+
+Check whether an address has at least the required access level for an IP.
+
+```rust
+pub fn check_ip_access(env: Env, ip_id: u64, grantee: Address, required_level: u32) -> bool
+```
+
+Returns `true` if the grantee's level ≥ `required_level`, or if `grantee` is the owner.
+
+```rust
+if registry.check_ip_access(&ip_id, &caller, &2u32) {
+    // caller can verify the commitment
+}
+```
+
+---
+
+### `get_ip_access_grants`
+
+Return all active access grants for an IP.
+
+```rust
+pub fn get_ip_access_grants(env: Env, ip_id: u64) -> Vec<IpAccessGrant>
+```
+
+Returns a `Vec<IpAccessGrant>` where each entry has `grantee: Address` and `access_level: u32`.


### PR DESCRIPTION
closes #427


Implementation (lib.rs + types.rs):
- IpAccessGrant struct with grantee: Address and access_level: u32
- IpAccessGrants(u64) storage key
- grant_ip_access — owner-only, levels 1–3, upserts on re-grant, emits ac_grant event
- revoke_ip_access — owner-only, no-op if grantee not found, emits ac_revoke event
- check_ip_access — hierarchical check, owner always passes
- get_ip_access_grants — list all grants for an IP

Tests (test.rs) — 12 tests covering:
- Each tier (view/verify/transfer) granted and checked
- Hierarchy (level 3 satisfies level 1 check)
- Owner always has full access
- Ungranteed address has no access
- Revoke removes access
- Upgrading a grant level (upsert, single entry)
- Multiple grantees
- Invalid levels (0 and 4) panic
- Revoke of non-existent grant is a no-op
- Grant and revoke events

Docs (docs/api-reference.md): Full Tiered Access Control section with tier table, all four function signatures, parameters, panics, events, and examples.