### PR TITLE
feat: batch swap features — reputation, insurance, arbitration, escrow

### DIFF
--- a/contracts/atomic_swap/src/batch_swap_features_tests.rs
+++ b/contracts/atomic_swap/src/batch_swap_features_tests.rs
@@ -1,0 +1,426 @@
+#[cfg(test)]
+mod batch_swap_features_tests {
+    use ip_registry::{IpRegistry, IpRegistryClient};
+    use soroban_sdk::{
+        testutils::Address as _,
+        token::StellarAssetClient,
+        Address, Bytes, BytesN, Env, Vec,
+    };
+
+    use crate::{AtomicSwap, AtomicSwapClient, SwapStatus};
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn setup_registry(env: &Env, owner: &Address) -> Address {
+        let registry_id = env.register(IpRegistry, ());
+        let _ = IpRegistryClient::new(env, &registry_id);
+        registry_id
+    }
+
+    fn commit_ip(env: &Env, registry_id: &Address, owner: &Address, seed: u8) -> (u64, BytesN<32>, BytesN<32>) {
+        let registry = IpRegistryClient::new(env, registry_id);
+        let secret = BytesN::from_array(env, &[seed; 32]);
+        let blinding = BytesN::from_array(env, &[seed.wrapping_add(0x80); 32]);
+        let mut preimage = Bytes::new(env);
+        preimage.append(&Bytes::from(secret.clone()));
+        preimage.append(&Bytes::from(blinding.clone()));
+        let hash: BytesN<32> = env.crypto().sha256(&preimage).into();
+        let ip_id = registry.commit_ip(owner, &hash);
+        (ip_id, secret, blinding)
+    }
+
+    fn setup_token(env: &Env, admin: &Address, recipient: &Address, amount: i128) -> Address {
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone()).address();
+        StellarAssetClient::new(env, &token_id).mint(recipient, &amount);
+        token_id
+    }
+
+    fn setup_contract(env: &Env, registry_id: &Address) -> Address {
+        let contract_id = env.register(AtomicSwap, ());
+        AtomicSwapClient::new(env, &contract_id).initialize(registry_id);
+        contract_id
+    }
+
+    // ── Reputation: batch_reveal_keys updates reputation ─────────────────────
+
+    #[test]
+    fn test_batch_reveal_keys_updates_reputation() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+
+        let registry_id = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 10_000_000);
+        let contract_id = setup_contract(&env, &registry_id);
+        let client = AtomicSwapClient::new(&env, &contract_id);
+
+        let (ip1, s1, b1) = commit_ip(&env, &registry_id, &seller, 0x01);
+        let (ip2, s2, b2) = commit_ip(&env, &registry_id, &seller, 0x02);
+
+        let mut ip_ids = Vec::new(&env);
+        ip_ids.push_back(ip1);
+        ip_ids.push_back(ip2);
+
+        let mut prices = Vec::new(&env);
+        prices.push_back(1000i128);
+        prices.push_back(2000i128);
+
+        let swap_ids = client.batch_initiate_swap(
+            &token_id, &ip_ids, &seller, &prices, &buyer, &0u32, &None,
+        );
+
+        let mut ids = Vec::new(&env);
+        ids.push_back(swap_ids.get(0).unwrap());
+        ids.push_back(swap_ids.get(1).unwrap());
+        client.batch_accept_swaps(&ids, &buyer);
+
+        let mut secrets = Vec::new(&env);
+        secrets.push_back(s1);
+        secrets.push_back(s2);
+
+        let mut blindings = Vec::new(&env);
+        blindings.push_back(b1);
+        blindings.push_back(b2);
+
+        // Before reveal: default reputation = 50
+        assert_eq!(client.get_reputation(&seller), 50);
+        assert_eq!(client.get_reputation(&buyer), 50);
+
+        client.batch_reveal_keys(&ids, &secrets, &blindings, &seller);
+
+        // After 2 completions: 50 + 2*5 = 60
+        assert_eq!(client.get_reputation(&seller), 60);
+        assert_eq!(client.get_reputation(&buyer), 60);
+    }
+
+    #[test]
+    fn test_batch_reveal_keys_single_swap_reputation() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+
+        let registry_id = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 10_000_000);
+        let contract_id = setup_contract(&env, &registry_id);
+        let client = AtomicSwapClient::new(&env, &contract_id);
+
+        let (ip1, s1, b1) = commit_ip(&env, &registry_id, &seller, 0x10);
+
+        let mut ip_ids = Vec::new(&env);
+        ip_ids.push_back(ip1);
+        let mut prices = Vec::new(&env);
+        prices.push_back(500i128);
+
+        let swap_ids = client.batch_initiate_swap(
+            &token_id, &ip_ids, &seller, &prices, &buyer, &0u32, &None,
+        );
+
+        let mut ids = Vec::new(&env);
+        ids.push_back(swap_ids.get(0).unwrap());
+        client.batch_accept_swaps(&ids, &buyer);
+
+        let mut secrets = Vec::new(&env);
+        secrets.push_back(s1);
+        let mut blindings = Vec::new(&env);
+        blindings.push_back(b1);
+
+        client.batch_reveal_keys(&ids, &secrets, &blindings, &seller);
+
+        // 50 + 5 = 55
+        assert_eq!(client.get_reputation(&seller), 55);
+        assert_eq!(client.get_reputation(&buyer), 55);
+    }
+
+    // ── Insurance: batch_accept_swaps collects insurance premiums ────────────
+
+    #[test]
+    fn test_batch_accept_swaps_collects_insurance_premium() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+
+        let registry_id = setup_registry(&env, &seller);
+        // Mint enough for price + insurance premium (2% of price)
+        let token_id = setup_token(&env, &admin, &buyer, 10_000_000);
+        let contract_id = setup_contract(&env, &registry_id);
+        let client = AtomicSwapClient::new(&env, &contract_id);
+
+        let (ip1, _, _) = commit_ip(&env, &registry_id, &seller, 0x20);
+        let (ip2, _, _) = commit_ip(&env, &registry_id, &seller, 0x21);
+
+        let mut ip_ids = Vec::new(&env);
+        ip_ids.push_back(ip1);
+        ip_ids.push_back(ip2);
+        let mut prices = Vec::new(&env);
+        prices.push_back(1000i128);
+        prices.push_back(2000i128);
+
+        // Initiate with insurance enabled
+        let swap_ids = client.batch_initiate_swap_with_insurance(
+            &token_id, &ip_ids, &seller, &prices, &buyer, &0u32, &None, &true,
+        );
+
+        let mut ids = Vec::new(&env);
+        ids.push_back(swap_ids.get(0).unwrap());
+        ids.push_back(swap_ids.get(1).unwrap());
+
+        // Accept — should collect premiums (20 + 40 = 60) into pool
+        client.batch_accept_swaps(&ids, &buyer);
+
+        // Verify swaps are Accepted
+        assert_eq!(client.get_swap(&ids.get(0).unwrap()).unwrap().status, SwapStatus::Accepted);
+        assert_eq!(client.get_swap(&ids.get(1).unwrap()).unwrap().status, SwapStatus::Accepted);
+    }
+
+    #[test]
+    fn test_batch_accept_swaps_no_insurance_no_premium() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+
+        let registry_id = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 10_000_000);
+        let contract_id = setup_contract(&env, &registry_id);
+        let client = AtomicSwapClient::new(&env, &contract_id);
+
+        let (ip1, _, _) = commit_ip(&env, &registry_id, &seller, 0x30);
+
+        let mut ip_ids = Vec::new(&env);
+        ip_ids.push_back(ip1);
+        let mut prices = Vec::new(&env);
+        prices.push_back(1000i128);
+
+        // No insurance
+        let swap_ids = client.batch_initiate_swap(
+            &token_id, &ip_ids, &seller, &prices, &buyer, &0u32, &None,
+        );
+
+        let mut ids = Vec::new(&env);
+        ids.push_back(swap_ids.get(0).unwrap());
+        client.batch_accept_swaps(&ids, &buyer);
+
+        let swap = client.get_swap(&ids.get(0).unwrap()).unwrap();
+        assert_eq!(swap.status, SwapStatus::Accepted);
+        assert!(!swap.insurance_enabled);
+        assert_eq!(swap.insurance_premium, 0);
+    }
+
+    // ── Arbitration: batch_arbitrate_swaps ────────────────────────────────────
+
+    #[test]
+    fn test_batch_arbitrate_swaps_refund() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let arbitrator = Address::generate(&env);
+        let admin = Address::generate(&env);
+
+        let registry_id = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 10_000_000);
+        let contract_id = setup_contract(&env, &registry_id);
+        let client = AtomicSwapClient::new(&env, &contract_id);
+
+        let (ip1, _, _) = commit_ip(&env, &registry_id, &seller, 0x40);
+        let (ip2, _, _) = commit_ip(&env, &registry_id, &seller, 0x41);
+
+        let mut ip_ids = Vec::new(&env);
+        ip_ids.push_back(ip1);
+        ip_ids.push_back(ip2);
+        let mut prices = Vec::new(&env);
+        prices.push_back(1000i128);
+        prices.push_back(2000i128);
+
+        let swap_ids = client.batch_initiate_swap(
+            &token_id, &ip_ids, &seller, &prices, &buyer, &0u32, &None,
+        );
+
+        let mut ids = Vec::new(&env);
+        ids.push_back(swap_ids.get(0).unwrap());
+        ids.push_back(swap_ids.get(1).unwrap());
+        client.batch_accept_swaps(&ids, &buyer);
+
+        // Raise disputes
+        client.raise_dispute(&ids.get(0).unwrap());
+        client.raise_dispute(&ids.get(1).unwrap());
+
+        // Batch arbitrate — refund both
+        client.batch_arbitrate_swaps(&ids, &arbitrator, &true);
+
+        assert_eq!(client.get_swap(&ids.get(0).unwrap()).unwrap().status, SwapStatus::Cancelled);
+        assert_eq!(client.get_swap(&ids.get(1).unwrap()).unwrap().status, SwapStatus::Cancelled);
+    }
+
+    #[test]
+    fn test_batch_arbitrate_swaps_complete() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let arbitrator = Address::generate(&env);
+        let admin = Address::generate(&env);
+
+        let registry_id = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 10_000_000);
+        let contract_id = setup_contract(&env, &registry_id);
+        let client = AtomicSwapClient::new(&env, &contract_id);
+
+        let (ip1, _, _) = commit_ip(&env, &registry_id, &seller, 0x50);
+
+        let mut ip_ids = Vec::new(&env);
+        ip_ids.push_back(ip1);
+        let mut prices = Vec::new(&env);
+        prices.push_back(1000i128);
+
+        let swap_ids = client.batch_initiate_swap(
+            &token_id, &ip_ids, &seller, &prices, &buyer, &0u32, &None,
+        );
+
+        let mut ids = Vec::new(&env);
+        ids.push_back(swap_ids.get(0).unwrap());
+        client.batch_accept_swaps(&ids, &buyer);
+        client.raise_dispute(&ids.get(0).unwrap());
+
+        // Batch arbitrate — complete (no refund)
+        client.batch_arbitrate_swaps(&ids, &arbitrator, &false);
+
+        assert_eq!(client.get_swap(&ids.get(0).unwrap()).unwrap().status, SwapStatus::Completed);
+    }
+
+    // ── Escrow: batch_escrow_deposit ──────────────────────────────────────────
+
+    #[test]
+    fn test_batch_escrow_deposit_moves_to_accepted() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+
+        let registry_id = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 10_000_000);
+        let contract_id = setup_contract(&env, &registry_id);
+        let client = AtomicSwapClient::new(&env, &contract_id);
+
+        let (ip1, _, _) = commit_ip(&env, &registry_id, &seller, 0x60);
+        let (ip2, _, _) = commit_ip(&env, &registry_id, &seller, 0x61);
+
+        let mut ip_ids = Vec::new(&env);
+        ip_ids.push_back(ip1);
+        ip_ids.push_back(ip2);
+        let mut prices = Vec::new(&env);
+        prices.push_back(500i128);
+        prices.push_back(800i128);
+        let timeout = env.ledger().timestamp() + 3600;
+        let mut timeouts = Vec::new(&env);
+        timeouts.push_back(timeout);
+        timeouts.push_back(timeout);
+
+        let swap_ids = client.batch_initiate_escrow(
+            &token_id, &ip_ids, &seller, &prices, &buyer, &timeouts,
+        );
+
+        // Both should be Pending
+        assert_eq!(client.get_swap(&swap_ids.get(0).unwrap()).unwrap().status, SwapStatus::Pending);
+        assert_eq!(client.get_swap(&swap_ids.get(1).unwrap()).unwrap().status, SwapStatus::Pending);
+
+        let mut ids = Vec::new(&env);
+        ids.push_back(swap_ids.get(0).unwrap());
+        ids.push_back(swap_ids.get(1).unwrap());
+
+        // Batch deposit
+        client.batch_escrow_deposit(&ids, &buyer);
+
+        // Both should be Accepted
+        assert_eq!(client.get_swap(&ids.get(0).unwrap()).unwrap().status, SwapStatus::Accepted);
+        assert_eq!(client.get_swap(&ids.get(1).unwrap()).unwrap().status, SwapStatus::Accepted);
+    }
+
+    #[test]
+    fn test_batch_escrow_deposit_single() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let admin = Address::generate(&env);
+
+        let registry_id = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 10_000_000);
+        let contract_id = setup_contract(&env, &registry_id);
+        let client = AtomicSwapClient::new(&env, &contract_id);
+
+        let (ip1, _, _) = commit_ip(&env, &registry_id, &seller, 0x70);
+
+        let mut ip_ids = Vec::new(&env);
+        ip_ids.push_back(ip1);
+        let mut prices = Vec::new(&env);
+        prices.push_back(1000i128);
+        let timeout = env.ledger().timestamp() + 3600;
+        let mut timeouts = Vec::new(&env);
+        timeouts.push_back(timeout);
+
+        let swap_ids = client.batch_initiate_escrow(
+            &token_id, &ip_ids, &seller, &prices, &buyer, &timeouts,
+        );
+
+        let mut ids = Vec::new(&env);
+        ids.push_back(swap_ids.get(0).unwrap());
+
+        client.batch_escrow_deposit(&ids, &buyer);
+
+        assert_eq!(client.get_swap(&ids.get(0).unwrap()).unwrap().status, SwapStatus::Accepted);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_batch_escrow_deposit_wrong_buyer_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        let other = Address::generate(&env);
+        let admin = Address::generate(&env);
+
+        let registry_id = setup_registry(&env, &seller);
+        let token_id = setup_token(&env, &admin, &buyer, 10_000_000);
+        let contract_id = setup_contract(&env, &registry_id);
+        let client = AtomicSwapClient::new(&env, &contract_id);
+
+        let (ip1, _, _) = commit_ip(&env, &registry_id, &seller, 0x80);
+
+        let mut ip_ids = Vec::new(&env);
+        ip_ids.push_back(ip1);
+        let mut prices = Vec::new(&env);
+        prices.push_back(500i128);
+        let timeout = env.ledger().timestamp() + 3600;
+        let mut timeouts = Vec::new(&env);
+        timeouts.push_back(timeout);
+
+        let swap_ids = client.batch_initiate_escrow(
+            &token_id, &ip_ids, &seller, &prices, &buyer, &timeouts,
+        );
+
+        let mut ids = Vec::new(&env);
+        ids.push_back(swap_ids.get(0).unwrap());
+
+        // Wrong buyer — must panic
+        client.batch_escrow_deposit(&ids, &other);
+    }
+}

--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -2906,6 +2906,70 @@ impl AtomicSwap {
         swap_ids
     }
 
+    /// Arbitrate multiple disputed swaps in one call. Arbitrator-only.
+    /// `refund` applies uniformly to all swaps in the batch.
+    pub fn batch_arbitrate_swaps(env: Env, swap_ids: Vec<u64>, arbitrator: Address, refund: bool) {
+        arbitrator.require_auth();
+
+        for swap_id in swap_ids.iter() {
+            let mut swap = require_swap_exists(&env, swap_id);
+            require_swap_status(&env, &swap, SwapStatus::Disputed, ContractError::NotDisputed);
+
+            let token_client = token::Client::new(&env, &swap.token);
+
+            if refund {
+                token_client.transfer(&env.current_contract_address(), &swap.buyer, &swap.price);
+
+                if swap.collateral_amount > 0 {
+                    if let Some(collateral) = env
+                        .storage()
+                        .persistent()
+                        .get::<_, i128>(&DataKey::SwapCollateral(swap_id))
+                    {
+                        token_client.transfer(&env.current_contract_address(), &swap.buyer, &collateral);
+                        env.storage().persistent().remove(&DataKey::SwapCollateral(swap_id));
+                    }
+                }
+
+                swap.status = SwapStatus::Cancelled;
+            } else {
+                let config = Self::protocol_config(&env);
+                let fee_amount = if config.protocol_fee_bps > 0 && swap.price > 0 {
+                    (swap.price * config.protocol_fee_bps as i128) / 10000
+                } else {
+                    0
+                };
+                let seller_amount = swap.price - fee_amount;
+                token_client.transfer(&env.current_contract_address(), &swap.seller, &seller_amount);
+                if fee_amount > 0 {
+                    token_client.transfer(&env.current_contract_address(), &config.treasury, &fee_amount);
+                }
+
+                if swap.collateral_amount > 0 {
+                    if let Some(collateral) = env
+                        .storage()
+                        .persistent()
+                        .get::<_, i128>(&DataKey::SwapCollateral(swap_id))
+                    {
+                        token_client.transfer(&env.current_contract_address(), &swap.seller, &collateral);
+                        env.storage().persistent().remove(&DataKey::SwapCollateral(swap_id));
+                    }
+                }
+
+                swap.status = SwapStatus::Completed;
+            }
+
+            swap::save_swap(&env, swap_id, &swap);
+            env.storage().persistent().remove(&DataKey::ActiveSwap(swap.ip_id));
+            Self::append_history(&env, swap_id, swap.status.clone());
+
+            env.events().publish(
+                (soroban_sdk::symbol_short!("arb_dec"),),
+                ArbitratedEvent { swap_id, arbitrator: arbitrator.clone(), refunded: refund },
+            );
+        }
+    }
+
     // ── #358: Swap Timeout Escalation ─────────────────────────────────────────
 
     /// Request timeout escalation. Buyer-only. Extends deadline if timeout imminent.

--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -2784,6 +2784,10 @@ impl AtomicSwap {
                     );
                 }
             }
+
+            // Update reputation on batch completion
+            Self::update_reputation(&env, &swap.seller, 5);
+            Self::update_reputation(&env, &swap.buyer, 5);
         }
 
         env.events().publish(

--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -2670,6 +2670,19 @@ impl AtomicSwap {
                 &swap.price,
             );
 
+            // #354: Collect insurance premium from buyer and add to pool.
+            if swap.insurance_enabled && swap.insurance_premium > 0 {
+                token_client.transfer(
+                    &swap.buyer,
+                    &env.current_contract_address(),
+                    &swap.insurance_premium,
+                );
+                let pool_key = DataKey::InsurancePool(swap.token.clone());
+                let pool: i128 = env.storage().persistent().get(&pool_key).unwrap_or(0);
+                env.storage().persistent().set(&pool_key, &(pool + swap.insurance_premium));
+                env.storage().persistent().extend_ttl(&pool_key, LEDGER_BUMP, LEDGER_BUMP);
+            }
+
             swap.accept_timestamp = env.ledger().timestamp();
             swap.status = SwapStatus::Accepted;
             swap::save_swap(&env, swap_id, &swap);
@@ -2797,6 +2810,100 @@ impl AtomicSwap {
                 seller,
             },
         );
+    }
+
+    /// Seller initiates multiple patent sales with optional insurance. Returns a Vec of swap IDs.
+    /// When `insurance_enabled` is true, each swap's premium is set to 2% of its price and
+    /// collected from the buyer at `batch_accept_swaps` time.
+    pub fn batch_initiate_swap_with_insurance(
+        env: Env,
+        token: Address,
+        ip_ids: Vec<u64>,
+        seller: Address,
+        prices: Vec<i128>,
+        buyer: Address,
+        required_approvals: u32,
+        referrer: Option<Address>,
+        insurance_enabled: bool,
+    ) -> Vec<u64> {
+        require_not_paused(&env);
+        seller.require_auth();
+
+        let len = ip_ids.len();
+        let mut swap_ids: Vec<u64> = Vec::new(&env);
+
+        for i in 0..len {
+            let ip_id = ip_ids.get(i).unwrap();
+            let price = prices.get(i).unwrap();
+
+            require_positive_price(&env, price);
+            registry::ensure_seller_owns_active_ip(&env, ip_id, &seller);
+            require_no_active_swap(&env, ip_id);
+
+            let id: u64 = env.storage().instance().get(&DataKey::NextId).unwrap_or(0);
+            let insurance_premium = if insurance_enabled { price * 2 / 100 } else { 0 };
+
+            let swap = SwapRecord {
+                ip_id,
+                seller: seller.clone(),
+                buyer: buyer.clone(),
+                price,
+                token: token.clone(),
+                status: SwapStatus::Pending,
+                expiry: env.ledger().timestamp() + 604800u64,
+                accept_timestamp: 0,
+                required_approvals,
+                dispute_timestamp: 0,
+                referrer: referrer.clone(),
+                collateral_amount: 0,
+                insurance_premium,
+                insurance_enabled,
+                escrow_agent: None,
+                quantity: 1,
+                conditions: Vec::new(&env),
+                paid_amount: 0,
+                is_installment: false,
+            };
+
+            if insurance_enabled {
+                env.storage().persistent().set(&DataKey::SwapInsurance(id), &insurance_premium);
+                env.storage().persistent().extend_ttl(&DataKey::SwapInsurance(id), LEDGER_BUMP, LEDGER_BUMP);
+            }
+
+            env.storage().persistent().set(&DataKey::Swap(id), &swap);
+            env.storage().persistent().extend_ttl(&DataKey::Swap(id), LEDGER_BUMP, LEDGER_BUMP);
+            env.storage().persistent().set(&DataKey::ActiveSwap(ip_id), &id);
+            env.storage().persistent().extend_ttl(&DataKey::ActiveSwap(ip_id), LEDGER_BUMP, LEDGER_BUMP);
+
+            swap::append_swap_for_party(&env, &seller, &buyer, id);
+
+            let mut ip_swap_ids: Vec<u64> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::IpSwaps(ip_id))
+                .unwrap_or(Vec::new(&env));
+            ip_swap_ids.push_back(id);
+            env.storage().persistent().set(&DataKey::IpSwaps(ip_id), &ip_swap_ids);
+            env.storage().persistent().extend_ttl(&DataKey::IpSwaps(ip_id), 50000, 50000);
+
+            Self::append_history(&env, id, SwapStatus::Pending);
+            env.storage().instance().set(&DataKey::NextId, &(id + 1));
+
+            env.events().publish(
+                (soroban_sdk::symbol_short!("swap_init"),),
+                SwapInitiatedEvent {
+                    swap_id: id,
+                    ip_id,
+                    seller: seller.clone(),
+                    buyer: buyer.clone(),
+                    price,
+                },
+            );
+
+            swap_ids.push_back(id);
+        }
+
+        swap_ids
     }
 
     // ── #358: Swap Timeout Escalation ─────────────────────────────────────────

--- a/contracts/atomic_swap/src/lib.rs
+++ b/contracts/atomic_swap/src/lib.rs
@@ -3093,6 +3093,8 @@ impl AtomicSwap {
                 escrow_agent: None,
                 quantity: 1,
                 conditions: Vec::new(&env),
+                paid_amount: 0,
+                is_installment: false,
             };
 
             env.storage().persistent().set(&DataKey::Swap(id), &swap);
@@ -3135,6 +3137,50 @@ impl AtomicSwap {
         }
 
         swap_ids
+    }
+
+    /// Buyer deposits funds into multiple escrow-mode swaps in one call.
+    /// Each swap must be in `Pending` status with `SwapMode::Escrow`.
+    pub fn batch_escrow_deposit(env: Env, swap_ids: Vec<u64>, buyer: Address) {
+        buyer.require_auth();
+
+        for swap_id in swap_ids.iter() {
+            let mut swap = require_swap_exists(&env, swap_id);
+
+            if swap.buyer != buyer {
+                env.panic_with_error(Error::from_contract_error(ContractError::Unauthorized as u32));
+            }
+
+            let mode: SwapMode = env
+                .storage()
+                .persistent()
+                .get(&DataKey::SwapMode(swap_id))
+                .unwrap_or(SwapMode::Atomic);
+            if mode != SwapMode::Escrow {
+                env.panic_with_error(Error::from_contract_error(ContractError::Unauthorized as u32));
+            }
+
+            require_swap_status(&env, &swap, SwapStatus::Pending, ContractError::NotPending);
+
+            token::Client::new(&env, &swap.token).transfer(
+                &swap.buyer,
+                &env.current_contract_address(),
+                &swap.price,
+            );
+
+            env.storage().persistent().set(&DataKey::EscrowDeposit(swap_id), &swap.price);
+            env.storage().persistent().extend_ttl(&DataKey::EscrowDeposit(swap_id), LEDGER_BUMP, LEDGER_BUMP);
+
+            swap.accept_timestamp = env.ledger().timestamp();
+            swap.status = SwapStatus::Accepted;
+            swap::save_swap(&env, swap_id, &swap);
+            Self::append_history(&env, swap_id, SwapStatus::Accepted);
+
+            env.events().publish(
+                (soroban_sdk::symbol_short!("esc_dep"),),
+                SwapAcceptedEvent { swap_id, buyer: swap.buyer },
+            );
+        }
     }
 
     /// Buyer deposits funds into escrow. Moves swap to `Accepted`.
@@ -3335,6 +3381,8 @@ impl AtomicSwap {
             escrow_agent: None,
             quantity: 1,
             conditions: Vec::new(&env),
+            paid_amount: 0,
+            is_installment: false,
         };
 
         env.storage().persistent().set(&DataKey::Swap(id), &swap);
@@ -3490,6 +3538,9 @@ impl AtomicSwap {
 
 // #[cfg(test)]
 // mod upgrade_chaos_tests;
+
+#[cfg(test)]
+mod batch_swap_features_tests;
 
 #[cfg(test)]
 mod installment_tests {


### PR DESCRIPTION
Closes #505 

Close #506 

Close #507 

Closes #508 


## Summary

Implements four batch swap features, each as a separate commit:

### 1. Reputation for batch swaps
- `batch_reveal_keys` now calls `update_reputation(+5)` for both seller and buyer on each completed swap, mirroring the single-swap `reveal_key` path.

### 2. Insurance for batch swaps
- `batch_accept_swaps` now collects insurance premiums from the buyer and deposits them into the `InsurancePool`, mirroring `accept_swap`.
- New `batch_initiate_swap_with_insurance`: batch initiation with `insurance_enabled` flag; sets premium to 2% of each swap price.

### 3. Arbitration for batch swaps
- New `batch_arbitrate_swaps`: resolves multiple `Disputed` swaps in one call. Arbitrator decides refund (→ Cancelled) or complete (→ Completed) uniformly for the batch, handling collateral and protocol fees.

### 4. Escrow payments for batch swaps
- New `batch_escrow_deposit`: buyer deposits into multiple escrow-mode swaps in one call, moving each from `Pending` to `Accepted`.
- Fixed `batch_initiate_escrow` and `initiate_swap_with_signers`: added missing `paid_amount`/`is_installment` fields to `SwapRecord` construction.

### Tests
New `batch_swap_features_tests` module with 9 tests covering all four features.