### PR TITLE
feat: Implement Swap Batch Fee Calculation [#502]

### DIFF
--- a/docs/swap-batch-fee-calculation.md
+++ b/docs/swap-batch-fee-calculation.md
@@ -1,0 +1,42 @@
+# Swap Batch Fee Calculation
+
+## Overview
+`calculateBatchFees(swaps, options?)` computes fees for a batch of atomic swaps
+with volume-tiered rates, a per-swap base fee, an optional batch discount, and a
+protocol/LP fee split.
+
+## Fee Structure
+
+| Component            | Value          |
+|----------------------|----------------|
+| Base fee per swap    | 0.001 tokens   |
+| Default rate         | 30 bps (0.30%) |
+| Mid-volume (≥10k)    | 25 bps         |
+| High-volume (≥100k)  | 20 bps         |
+| Institutional (≥1M)  | 15 bps         |
+| Batch discount       | 5 bps off total|
+| Protocol split       | 20% of net fee |
+| LP split             | 80% of net fee |
+
+## Usage
+```js
+const { calculateBatchFees } = require('./src/batch/batchFeeCalculator');
+
+const result = calculateBatchFees([
+  { id: 'swap-1', amount: 10, value: 5000 },
+  { id: 'swap-2', amount: 3,  value: 1500 },
+]);
+
+console.log(result.totalNetFee);   // total fee charged
+console.log(result.totalProtocolFee); // platform revenue
+```
+
+## Options
+| Option               | Type    | Default | Description                          |
+|----------------------|---------|---------|--------------------------------------|
+| `overrideFeeBps`     | number  | —       | Override tier lookup with fixed rate |
+| `applyBatchDiscount` | boolean | true    | Apply 5bps batch discount            |
+
+## Constraints
+- Batch size: 1–100 swaps
+- All `amount` and `value` fields must be positive numbers

--- a/src/__tests__/batchFeeCalculator.test.js
+++ b/src/__tests__/batchFeeCalculator.test.js
@@ -1,0 +1,88 @@
+const {
+  calculateBatchFees,
+  getTierRate,
+  FEE_TIERS,
+  BASE_FEE_PER_SWAP,
+  MAX_BATCH_SIZE,
+} = require("../batch/batchFeeCalculator");
+
+describe("getTierRate", () => {
+  test("returns default 30bps for low volume", () => {
+    expect(getTierRate(0)).toBe(30);
+    expect(getTierRate(9999)).toBe(30);
+  });
+  test("returns 25bps at 10k threshold", () => {
+    expect(getTierRate(10_000)).toBe(25);
+  });
+  test("returns 15bps at institutional threshold", () => {
+    expect(getTierRate(1_000_000)).toBe(15);
+  });
+});
+
+describe("calculateBatchFees — validation", () => {
+  test("throws on empty array", () => {
+    expect(() => calculateBatchFees([])).toThrow(TypeError);
+  });
+  test("throws on non-array", () => {
+    expect(() => calculateBatchFees(null)).toThrow(TypeError);
+  });
+  test("throws on batch size > MAX_BATCH_SIZE", () => {
+    const big = Array.from({ length: MAX_BATCH_SIZE + 1 }, (_, i) => ({ amount: 1, value: 100 }));
+    expect(() => calculateBatchFees(big)).toThrow(RangeError);
+  });
+  test("throws on negative amount", () => {
+    expect(() => calculateBatchFees([{ amount: -1, value: 100 }])).toThrow(RangeError);
+  });
+  test("throws on zero value", () => {
+    expect(() => calculateBatchFees([{ amount: 1, value: 0 }])).toThrow(RangeError);
+  });
+});
+
+describe("calculateBatchFees — fee maths", () => {
+  const swaps = [
+    { id: "a", amount: 10, value: 1000 },
+    { id: "b", amount: 5,  value: 500  },
+  ];
+
+  test("returns correct batch size and total volume", () => {
+    const result = calculateBatchFees(swaps);
+    expect(result.batchSize).toBe(2);
+    expect(result.totalVolume).toBeCloseTo(1500);
+  });
+
+  test("netFee < grossFee when batch discount applied", () => {
+    const result = calculateBatchFees(swaps);
+    result.swapFees.forEach((f) => {
+      expect(f.netFee).toBeLessThan(f.grossFee);
+    });
+  });
+
+  test("protocolFee + lpFee === netFee for each swap", () => {
+    const result = calculateBatchFees(swaps);
+    result.swapFees.forEach((f) => {
+      expect(f.protocolFee + f.lpFee).toBeCloseTo(f.netFee, 6);
+    });
+  });
+
+  test("totals match sum of individual swap fees", () => {
+    const result = calculateBatchFees(swaps);
+    const sumNet = result.swapFees.reduce((s, f) => s + f.netFee, 0);
+    expect(result.totalNetFee).toBeCloseTo(sumNet, 6);
+  });
+
+  test("overrideFeeBps is respected", () => {
+    const result = calculateBatchFees(swaps, { overrideFeeBps: 10 });
+    expect(result.effectiveFeeBps).toBe(10);
+  });
+
+  test("no discount when applyBatchDiscount=false", () => {
+    const result = calculateBatchFees(swaps, { applyBatchDiscount: false });
+    result.swapFees.forEach((f) => expect(f.discountAmount).toBe(0));
+  });
+
+  test("uses lower tier for high-volume batch", () => {
+    const bigSwaps = [{ amount: 1, value: 1_000_000 }];
+    const result = calculateBatchFees(bigSwaps);
+    expect(result.effectiveFeeBps).toBe(15);
+  });
+});

--- a/src/batch/batchFeeCalculator.js
+++ b/src/batch/batchFeeCalculator.js
@@ -1,0 +1,139 @@
+/**
+ * Swap Batch Fee Calculation
+ * ─────────────────────────
+ * Calculates fees for a batch of swaps with support for:
+ *  - Per-swap base fee
+ *  - Volume-tiered fee rates
+ *  - Batch discount (economies of scale)
+ *  - Protocol fee split (platform vs liquidity providers)
+ */
+
+// ── Fee rate tiers (basis points) ────────────────────────────────────────────
+const FEE_TIERS = [
+  { minVolume: 0,          bps: 30  }, // 0.30% — default
+  { minVolume: 10_000,     bps: 25  }, // 0.25% — mid tier
+  { minVolume: 100_000,    bps: 20  }, // 0.20% — high volume
+  { minVolume: 1_000_000,  bps: 15  }, // 0.15% — institutional
+];
+
+const BASE_FEE_PER_SWAP   = 0.001;  // flat fee per swap entry (in token units)
+const BATCH_DISCOUNT_BPS  = 5;      // 0.05% discount applied to total fee for batch
+const PROTOCOL_SPLIT_BPS  = 2000;   // 20% of fee goes to protocol treasury
+const MAX_BATCH_SIZE       = 100;
+const BPS_DENOM            = 10_000;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function getTierRate(volume) {
+  let bps = FEE_TIERS[0].bps;
+  for (const tier of FEE_TIERS) {
+    if (volume >= tier.minVolume) bps = tier.bps;
+  }
+  return bps;
+}
+
+function validateSwap(swap, index) {
+  if (!swap || typeof swap !== "object")
+    throw new TypeError(`Swap at index ${index} must be an object.`);
+  if (typeof swap.amount !== "number" || swap.amount <= 0)
+    throw new RangeError(`Swap at index ${index}: amount must be a positive number.`);
+  if (typeof swap.value !== "number" || swap.value <= 0)
+    throw new RangeError(`Swap at index ${index}: value must be a positive number.`);
+}
+
+// ── Core calculation ──────────────────────────────────────────────────────────
+
+/**
+ * Calculate fees for a batch of swaps.
+ *
+ * @param {Array<{ id?: string, amount: number, value: number }>} swaps
+ * @param {{ overrideFeeBps?: number, applyBatchDiscount?: boolean }} [options]
+ * @returns {BatchFeeResult}
+ *
+ * @typedef {Object} SwapFee
+ * @property {string|number} id
+ * @property {number} amount
+ * @property {number} value
+ * @property {number} feeBps
+ * @property {number} grossFee      - volume-rate fee + base fee
+ * @property {number} discountAmount
+ * @property {number} netFee
+ * @property {number} protocolFee
+ * @property {number} lpFee
+ *
+ * @typedef {Object} BatchFeeResult
+ * @property {number} batchSize
+ * @property {number} totalVolume
+ * @property {number} effectiveFeeBps
+ * @property {number} totalGrossFee
+ * @property {number} totalDiscount
+ * @property {number} totalNetFee
+ * @property {number} totalProtocolFee
+ * @property {number} totalLpFee
+ * @property {SwapFee[]} swapFees
+ */
+function calculateBatchFees(swaps, options = {}) {
+  if (!Array.isArray(swaps) || swaps.length === 0)
+    throw new TypeError("swaps must be a non-empty array.");
+  if (swaps.length > MAX_BATCH_SIZE)
+    throw new RangeError(`Batch size ${swaps.length} exceeds maximum of ${MAX_BATCH_SIZE}.`);
+
+  swaps.forEach(validateSwap);
+
+  const { overrideFeeBps, applyBatchDiscount = true } = options;
+  const totalVolume = swaps.reduce((s, sw) => s + sw.value, 0);
+  const tierBps = overrideFeeBps ?? getTierRate(totalVolume);
+
+  const swapFees = swaps.map((swap, i) => {
+    const volumeFee = (swap.value * tierBps) / BPS_DENOM;
+    const grossFee  = volumeFee + BASE_FEE_PER_SWAP;
+
+    const discountAmount = applyBatchDiscount
+      ? (grossFee * BATCH_DISCOUNT_BPS) / BPS_DENOM
+      : 0;
+
+    const netFee      = grossFee - discountAmount;
+    const protocolFee = (netFee * PROTOCOL_SPLIT_BPS) / BPS_DENOM;
+    const lpFee       = netFee - protocolFee;
+
+    return {
+      id:             swap.id ?? i,
+      amount:         swap.amount,
+      value:          swap.value,
+      feeBps:         tierBps,
+      grossFee:       +grossFee.toFixed(8),
+      discountAmount: +discountAmount.toFixed(8),
+      netFee:         +netFee.toFixed(8),
+      protocolFee:    +protocolFee.toFixed(8),
+      lpFee:          +lpFee.toFixed(8),
+    };
+  });
+
+  const totalGrossFee    = swapFees.reduce((s, f) => s + f.grossFee, 0);
+  const totalDiscount    = swapFees.reduce((s, f) => s + f.discountAmount, 0);
+  const totalNetFee      = swapFees.reduce((s, f) => s + f.netFee, 0);
+  const totalProtocolFee = swapFees.reduce((s, f) => s + f.protocolFee, 0);
+  const totalLpFee       = swapFees.reduce((s, f) => s + f.lpFee, 0);
+
+  return {
+    batchSize:        swaps.length,
+    totalVolume:      +totalVolume.toFixed(8),
+    effectiveFeeBps:  tierBps,
+    totalGrossFee:    +totalGrossFee.toFixed(8),
+    totalDiscount:    +totalDiscount.toFixed(8),
+    totalNetFee:      +totalNetFee.toFixed(8),
+    totalProtocolFee: +totalProtocolFee.toFixed(8),
+    totalLpFee:       +totalLpFee.toFixed(8),
+    swapFees,
+  };
+}
+
+module.exports = {
+  calculateBatchFees,
+  getTierRate,
+  FEE_TIERS,
+  BASE_FEE_PER_SWAP,
+  BATCH_DISCOUNT_BPS,
+  PROTOCOL_SPLIT_BPS,
+  MAX_BATCH_SIZE,
+};


### PR DESCRIPTION
## Summary
Calculates fees for a batch of atomic swaps with volume-tiered rates, batch discount, and protocol/LP split.

## Changes
- \`src/batch/batchFeeCalculator.js\`: \`calculateBatchFees(swaps, options)\`
  - Volume tiers: 30/25/20/15 bps at 0/10k/100k/1M thresholds
  - Base fee: 0.001 tokens per swap entry
  - Batch discount: 5 bps applied to each swap's gross fee
  - Protocol split: 20% → treasury, 80% → LPs
  - Validation: empty/non-array, oversized batch (>100), negative/zero values
- \`src/__tests__/batchFeeCalculator.test.js\`: 11 tests — tier lookup, validation, fee maths invariants, override, discount toggle, high-volume tier
- \`docs/swap-batch-fee-calculation.md\`: fee structure table, usage example, options reference

Closes #502