### PR TITLE
feat: Add Swap Batch Dispute Resolution [#501]

### DIFF
--- a/docs/swap-batch-dispute-resolution.md
+++ b/docs/swap-batch-dispute-resolution.md
@@ -1,0 +1,45 @@
+# Swap Batch Dispute Resolution
+
+## Overview
+`resolveBatchDisputes(disputes, resolutions)` resolves disputes for multiple swaps
+in a single pass, returning per-swap outcomes and batch-level totals.
+
+## Dispute States
+| State     | Description                          |
+|-----------|--------------------------------------|
+| OPEN      | Dispute is active and resolvable     |
+| RESOLVED  | Dispute resolved (refund/release/split)|
+| ESCALATED | Handed off to human arbitration      |
+
+## Resolution Types
+| Type     | Outcome                                      |
+|----------|----------------------------------------------|
+| REFUND   | Full amount returned to initiator            |
+| RELEASE  | Full amount released to counterparty         |
+| SPLIT    | Amount split by `splitRatio` (default 50/50) |
+| ESCALATE | Marked for human arbitration, funds frozen   |
+
+## Usage
+```js
+const { resolveBatchDisputes, DISPUTE_STATES, RESOLUTION_TYPES } =
+  require('./src/batch/batchDisputeResolver');
+
+const result = resolveBatchDisputes(
+  [
+    { swapId: 'swap-1', state: 'OPEN', amount: 500 },
+    { swapId: 'swap-2', state: 'OPEN', amount: 300 },
+  ],
+  [
+    { type: 'REFUND' },
+    { type: 'SPLIT', splitRatio: 0.6, reason: 'Partial delivery' },
+  ]
+);
+
+console.log(result.resolvedCount); // 2
+console.log(result.totalRefunded); // 500
+```
+
+## Constraints
+- Batch size: 1–50 disputes
+- Only OPEN disputes can be resolved; others are recorded as errors (non-throwing)
+- `splitRatio` must be between 0.01 and 0.99

--- a/src/__tests__/batchDisputeResolver.test.js
+++ b/src/__tests__/batchDisputeResolver.test.js
@@ -1,0 +1,101 @@
+const {
+  resolveBatchDisputes,
+  DISPUTE_STATES,
+  RESOLUTION_TYPES,
+  MAX_BATCH_SIZE,
+} = require("../batch/batchDisputeResolver");
+
+const openDispute = (id, amount = 1000) => ({
+  swapId: id, state: DISPUTE_STATES.OPEN, amount,
+});
+
+describe("resolveBatchDisputes — validation", () => {
+  test("throws on empty disputes array", () => {
+    expect(() => resolveBatchDisputes([], [])).toThrow(TypeError);
+  });
+  test("throws when arrays length mismatch", () => {
+    expect(() => resolveBatchDisputes([openDispute("a")], [])).toThrow(TypeError);
+  });
+  test("throws on batch > MAX_BATCH_SIZE", () => {
+    const big = Array.from({ length: MAX_BATCH_SIZE + 1 }, (_, i) => openDispute(`s${i}`));
+    const res = big.map(() => ({ type: RESOLUTION_TYPES.REFUND }));
+    expect(() => resolveBatchDisputes(big, res)).toThrow(RangeError);
+  });
+  test("records error for non-OPEN dispute without throwing", () => {
+    const d = [{ swapId: "x", state: DISPUTE_STATES.RESOLVED, amount: 100 }];
+    const r = [{ type: RESOLUTION_TYPES.REFUND }];
+    const result = resolveBatchDisputes(d, r);
+    expect(result.failedCount).toBe(1);
+    expect(result.errors[0].swapId).toBe("x");
+  });
+});
+
+describe("resolveBatchDisputes — resolution types", () => {
+  test("REFUND returns full amount to initiator", () => {
+    const result = resolveBatchDisputes(
+      [openDispute("r1", 500)],
+      [{ type: RESOLUTION_TYPES.REFUND }]
+    );
+    expect(result.resolvedCount).toBe(1);
+    expect(result.results[0].initiatorAmount).toBe(500);
+    expect(result.results[0].counterpartyAmount).toBe(0);
+    expect(result.totalRefunded).toBe(500);
+  });
+
+  test("RELEASE sends full amount to counterparty", () => {
+    const result = resolveBatchDisputes(
+      [openDispute("r2", 750)],
+      [{ type: RESOLUTION_TYPES.RELEASE }]
+    );
+    expect(result.results[0].counterpartyAmount).toBe(750);
+    expect(result.results[0].initiatorAmount).toBe(0);
+    expect(result.totalReleased).toBe(750);
+  });
+
+  test("SPLIT with default ratio distributes 50/50", () => {
+    const result = resolveBatchDisputes(
+      [openDispute("r3", 1000)],
+      [{ type: RESOLUTION_TYPES.SPLIT }]
+    );
+    expect(result.results[0].initiatorAmount).toBeCloseTo(500);
+    expect(result.results[0].counterpartyAmount).toBeCloseTo(500);
+  });
+
+  test("SPLIT with custom ratio respects ratio", () => {
+    const result = resolveBatchDisputes(
+      [openDispute("r4", 1000)],
+      [{ type: RESOLUTION_TYPES.SPLIT, splitRatio: 0.7 }]
+    );
+    expect(result.results[0].initiatorAmount).toBeCloseTo(700);
+    expect(result.results[0].counterpartyAmount).toBeCloseTo(300);
+  });
+
+  test("ESCALATE moves state to ESCALATED", () => {
+    const result = resolveBatchDisputes(
+      [openDispute("r5")],
+      [{ type: RESOLUTION_TYPES.ESCALATE, reason: "Complex case" }]
+    );
+    expect(result.escalatedCount).toBe(1);
+    expect(result.results[0].newState).toBe(DISPUTE_STATES.ESCALATED);
+  });
+});
+
+describe("resolveBatchDisputes — mixed batch", () => {
+  test("processes mixed outcomes and counts correctly", () => {
+    const disputes = [
+      openDispute("m1", 100),
+      openDispute("m2", 200),
+      { swapId: "m3", state: DISPUTE_STATES.RESOLVED, amount: 300 }, // will fail
+    ];
+    const resolutions = [
+      { type: RESOLUTION_TYPES.REFUND },
+      { type: RESOLUTION_TYPES.RELEASE },
+      { type: RESOLUTION_TYPES.REFUND },
+    ];
+    const result = resolveBatchDisputes(disputes, resolutions);
+    expect(result.resolvedCount).toBe(2);
+    expect(result.failedCount).toBe(1);
+    expect(result.totalRefunded).toBe(100);
+    expect(result.totalReleased).toBe(200);
+  });
+});

--- a/src/batch/batchDisputeResolver.js
+++ b/src/batch/batchDisputeResolver.js
@@ -1,0 +1,198 @@
+/**
+ * Swap Batch Dispute Resolution
+ * ─────────────────────────────
+ * Resolves disputes for multiple swaps in a single batch operation.
+ *
+ * Dispute lifecycle:
+ *   OPEN → (RESOLVED | REJECTED | ESCALATED)
+ *
+ * Resolution types:
+ *   - REFUND:   Return funds to initiator
+ *   - RELEASE:  Release funds to counterparty
+ *   - SPLIT:    Split funds by a configured ratio
+ *   - ESCALATE: Hand off to human arbitration
+ */
+
+const DISPUTE_STATES = Object.freeze({
+  OPEN:      "OPEN",
+  RESOLVED:  "RESOLVED",
+  REJECTED:  "REJECTED",
+  ESCALATED: "ESCALATED",
+});
+
+const RESOLUTION_TYPES = Object.freeze({
+  REFUND:   "REFUND",
+  RELEASE:  "RELEASE",
+  SPLIT:    "SPLIT",
+  ESCALATE: "ESCALATE",
+});
+
+const MAX_BATCH_SIZE       = 50;
+const DEFAULT_SPLIT_RATIO  = 0.5; // 50/50 if not specified
+const VALID_SPLIT_RANGE    = [0.01, 0.99];
+
+// ── Validators ────────────────────────────────────────────────────────────────
+
+function validateDispute(dispute, index) {
+  if (!dispute || typeof dispute !== "object")
+    throw new TypeError(`Dispute at index ${index} must be an object.`);
+  if (!dispute.swapId)
+    throw new TypeError(`Dispute at index ${index}: swapId is required.`);
+  if (!Object.values(DISPUTE_STATES).includes(dispute.state))
+    throw new TypeError(`Dispute at index ${index}: invalid state '${dispute.state}'.`);
+  if (dispute.state !== DISPUTE_STATES.OPEN)
+    throw new Error(`Dispute ${dispute.swapId}: only OPEN disputes can be resolved (got '${dispute.state}').`);
+  if (typeof dispute.amount !== "number" || dispute.amount <= 0)
+    throw new RangeError(`Dispute ${dispute.swapId}: amount must be a positive number.`);
+}
+
+function validateResolution(resolution, dispute) {
+  if (!resolution || typeof resolution !== "object")
+    throw new TypeError(`Resolution for swap ${dispute.swapId} must be an object.`);
+  if (!Object.values(RESOLUTION_TYPES).includes(resolution.type))
+    throw new TypeError(`Resolution for swap ${dispute.swapId}: invalid type '${resolution.type}'.`);
+  if (resolution.type === RESOLUTION_TYPES.SPLIT) {
+    const ratio = resolution.splitRatio ?? DEFAULT_SPLIT_RATIO;
+    if (ratio < VALID_SPLIT_RANGE[0] || ratio > VALID_SPLIT_RANGE[1])
+      throw new RangeError(
+        `Dispute ${dispute.swapId}: splitRatio must be between ${VALID_SPLIT_RANGE[0]} and ${VALID_SPLIT_RANGE[1]}.`
+      );
+  }
+}
+
+// ── Resolution logic ──────────────────────────────────────────────────────────
+
+function resolveOne(dispute, resolution) {
+  const { type, splitRatio = DEFAULT_SPLIT_RATIO, reason = "" } = resolution;
+
+  switch (type) {
+    case RESOLUTION_TYPES.REFUND:
+      return {
+        swapId:           dispute.swapId,
+        originalState:    dispute.state,
+        newState:         DISPUTE_STATES.RESOLVED,
+        resolutionType:   type,
+        initiatorAmount:  dispute.amount,
+        counterpartyAmount: 0,
+        reason,
+        resolvedAt:       new Date().toISOString(),
+      };
+
+    case RESOLUTION_TYPES.RELEASE:
+      return {
+        swapId:             dispute.swapId,
+        originalState:      dispute.state,
+        newState:           DISPUTE_STATES.RESOLVED,
+        resolutionType:     type,
+        initiatorAmount:    0,
+        counterpartyAmount: dispute.amount,
+        reason,
+        resolvedAt:         new Date().toISOString(),
+      };
+
+    case RESOLUTION_TYPES.SPLIT: {
+      const initiatorShare    = +(dispute.amount * splitRatio).toFixed(8);
+      const counterpartyShare = +(dispute.amount - initiatorShare).toFixed(8);
+      return {
+        swapId:             dispute.swapId,
+        originalState:      dispute.state,
+        newState:           DISPUTE_STATES.RESOLVED,
+        resolutionType:     type,
+        splitRatio,
+        initiatorAmount:    initiatorShare,
+        counterpartyAmount: counterpartyShare,
+        reason,
+        resolvedAt:         new Date().toISOString(),
+      };
+    }
+
+    case RESOLUTION_TYPES.ESCALATE:
+      return {
+        swapId:           dispute.swapId,
+        originalState:    dispute.state,
+        newState:         DISPUTE_STATES.ESCALATED,
+        resolutionType:   type,
+        initiatorAmount:  null,
+        counterpartyAmount: null,
+        reason,
+        resolvedAt:       new Date().toISOString(),
+      };
+
+    default:
+      throw new Error(`Unknown resolution type: ${type}`);
+  }
+}
+
+// ── Batch entry point ─────────────────────────────────────────────────────────
+
+/**
+ * Resolve disputes for a batch of swaps.
+ *
+ * @param {Array<DisputeEntry>} disputes
+ * @param {Array<ResolutionEntry>} resolutions  - parallel array, same order as disputes
+ * @returns {BatchDisputeResult}
+ *
+ * @typedef {{ swapId: string, state: string, amount: number }} DisputeEntry
+ * @typedef {{ type: string, splitRatio?: number, reason?: string }} ResolutionEntry
+ *
+ * @typedef {Object} BatchDisputeResult
+ * @property {number} batchSize
+ * @property {number} resolvedCount
+ * @property {number} escalatedCount
+ * @property {number} failedCount
+ * @property {number} totalRefunded
+ * @property {number} totalReleased
+ * @property {number} totalSplit
+ * @property {Array}  results
+ * @property {Array}  errors
+ */
+function resolveBatchDisputes(disputes, resolutions) {
+  if (!Array.isArray(disputes) || disputes.length === 0)
+    throw new TypeError("disputes must be a non-empty array.");
+  if (!Array.isArray(resolutions) || resolutions.length !== disputes.length)
+    throw new TypeError("resolutions must be an array of the same length as disputes.");
+  if (disputes.length > MAX_BATCH_SIZE)
+    throw new RangeError(`Batch size ${disputes.length} exceeds maximum of ${MAX_BATCH_SIZE}.`);
+
+  const results = [];
+  const errors  = [];
+
+  for (let i = 0; i < disputes.length; i++) {
+    try {
+      validateDispute(disputes[i], i);
+      validateResolution(resolutions[i], disputes[i]);
+      results.push(resolveOne(disputes[i], resolutions[i]));
+    } catch (err) {
+      errors.push({ index: i, swapId: disputes[i]?.swapId ?? null, error: err.message });
+    }
+  }
+
+  const resolved   = results.filter((r) => r.newState === DISPUTE_STATES.RESOLVED);
+  const escalated  = results.filter((r) => r.newState === DISPUTE_STATES.ESCALATED);
+
+  const totalRefunded  = resolved.filter((r) => r.resolutionType === RESOLUTION_TYPES.REFUND)
+                                  .reduce((s, r) => s + r.initiatorAmount, 0);
+  const totalReleased  = resolved.filter((r) => r.resolutionType === RESOLUTION_TYPES.RELEASE)
+                                  .reduce((s, r) => s + r.counterpartyAmount, 0);
+  const totalSplit     = resolved.filter((r) => r.resolutionType === RESOLUTION_TYPES.SPLIT)
+                                  .reduce((s, r) => s + r.initiatorAmount + r.counterpartyAmount, 0);
+
+  return {
+    batchSize:       disputes.length,
+    resolvedCount:   resolved.length,
+    escalatedCount:  escalated.length,
+    failedCount:     errors.length,
+    totalRefunded:   +totalRefunded.toFixed(8),
+    totalReleased:   +totalReleased.toFixed(8),
+    totalSplit:      +totalSplit.toFixed(8),
+    results,
+    errors,
+  };
+}
+
+module.exports = {
+  resolveBatchDisputes,
+  DISPUTE_STATES,
+  RESOLUTION_TYPES,
+  MAX_BATCH_SIZE,
+};


### PR DESCRIPTION
## Summary
Resolves disputes for multiple swaps in one batch call with four resolution types and non-throwing error capture per item.

## Changes
- \`src/batch/batchDisputeResolver.js\`: \`resolveBatchDisputes(disputes, resolutions)\`
  - Types: REFUND (full → initiator), RELEASE (full → counterparty), SPLIT (ratio, default 50/50), ESCALATE (freeze + hand off)
  - Per-item validation: only OPEN disputes processable; invalid items logged to \`errors[]\` without aborting batch
  - Batch totals: \`resolvedCount\`, \`escalatedCount\`, \`failedCount\`, \`totalRefunded\`, \`totalReleased\`, \`totalSplit\`
  - Max 50 disputes per batch
- \`src/__tests__/batchDisputeResolver.test.js\`: 10 tests — validation, all resolution types, custom split ratio, mixed outcomes
- \`docs/swap-batch-dispute-resolution.md\`: state/resolution tables, usage example, constraints

Closes #501