### PR TITLE
feat: Implement Swap Batch Expiry Extension [#500]

### DIFF
--- a/docs/swap-batch-expiry-extension.md
+++ b/docs/swap-batch-expiry-extension.md
@@ -1,0 +1,34 @@
+# Swap Batch Expiry Extension
+
+## Overview
+`extendBatchExpiry(swaps, extensions, options?)` extends the expiry timestamp for
+multiple swaps in a single operation. Non-extendable swaps are captured as errors
+without aborting the batch.
+
+## Extendable States
+Only `PENDING` and `ACTIVE` swaps can be extended. All other states (EXPIRED,
+COMPLETED, CANCELLED) are recorded as errors.
+
+## Extension Rules
+| Rule                    | Value                    |
+|-------------------------|--------------------------|
+| Minimum extension       | 1 minute (60,000 ms)     |
+| Maximum extension       | 30 days (2,592,000,000 ms) |
+| Max batch size          | 100 swaps                |
+
+## Usage
+```js
+const { extendBatchExpiry } = require('./src/batch/batchExpiryExtender');
+
+const ONE_DAY = 24 * 60 * 60 * 1000;
+
+// Same extension for all swaps
+const result = extendBatchExpiry(swaps, ONE_DAY);
+
+// Per-swap extensions
+const result = extendBatchExpiry(swaps, [ONE_DAY, 2 * ONE_DAY, ONE_DAY]);
+
+console.log(result.extendedCount);     // number successfully extended
+console.log(result.failedCount);       // number that failed (non-extendable state etc.)
+console.log(result.totalExtensionMs);  // total ms added across all swaps
+```

--- a/src/__tests__/batchExpiryExtender.test.js
+++ b/src/__tests__/batchExpiryExtender.test.js
@@ -1,0 +1,91 @@
+const {
+  extendBatchExpiry,
+  MAX_EXTENSION_MS,
+  MIN_EXTENSION_MS,
+  MAX_BATCH_SIZE,
+} = require("../batch/batchExpiryExtender");
+
+const NOW = new Date("2024-06-01T12:00:00.000Z").getTime();
+const ONE_HOUR = 60 * 60 * 1000;
+const ONE_DAY  = 24 * ONE_HOUR;
+
+const pendingSwap = (id, offsetMs = ONE_DAY) => ({
+  swapId:    id,
+  state:     "PENDING",
+  expiresAt: new Date(NOW + offsetMs).toISOString(),
+});
+
+describe("extendBatchExpiry — validation", () => {
+  test("throws on empty array", () => {
+    expect(() => extendBatchExpiry([], ONE_HOUR, { now: NOW })).toThrow(TypeError);
+  });
+  test("throws on batch > MAX_BATCH_SIZE", () => {
+    const big = Array.from({ length: MAX_BATCH_SIZE + 1 }, (_, i) => pendingSwap(`s${i}`));
+    expect(() => extendBatchExpiry(big, ONE_HOUR, { now: NOW })).toThrow(RangeError);
+  });
+  test("throws on extension below MIN_EXTENSION_MS", () => {
+    expect(() =>
+      extendBatchExpiry([pendingSwap("a")], MIN_EXTENSION_MS - 1, { now: NOW })
+    ).toThrow(RangeError);
+  });
+  test("throws on extension above MAX_EXTENSION_MS", () => {
+    expect(() =>
+      extendBatchExpiry([pendingSwap("a")], MAX_EXTENSION_MS + 1, { now: NOW })
+    ).toThrow(RangeError);
+  });
+  test("records error for non-extendable state", () => {
+    const expired = { swapId: "ex1", state: "EXPIRED", expiresAt: new Date(NOW - ONE_DAY).toISOString() };
+    const result = extendBatchExpiry([expired], ONE_HOUR, { now: NOW });
+    expect(result.failedCount).toBe(1);
+    expect(result.errors[0].swapId).toBe("ex1");
+  });
+});
+
+describe("extendBatchExpiry — extension logic", () => {
+  test("extends a single PENDING swap correctly", () => {
+    const result = extendBatchExpiry([pendingSwap("p1")], ONE_HOUR, { now: NOW });
+    expect(result.extendedCount).toBe(1);
+    const newExpiry  = new Date(result.results[0].newExpiry).getTime();
+    const prevExpiry = new Date(result.results[0].previousExpiry).getTime();
+    expect(newExpiry - prevExpiry).toBe(ONE_HOUR);
+  });
+
+  test("applies single extension value to all swaps", () => {
+    const swaps = [pendingSwap("b1"), pendingSwap("b2"), pendingSwap("b3")];
+    const result = extendBatchExpiry(swaps, ONE_DAY, { now: NOW });
+    expect(result.extendedCount).toBe(3);
+    result.results.forEach((r) => expect(r.extensionMs).toBe(ONE_DAY));
+  });
+
+  test("applies per-swap extension array", () => {
+    const swaps      = [pendingSwap("c1"), pendingSwap("c2")];
+    const extensions = [ONE_HOUR, ONE_DAY];
+    const result     = extendBatchExpiry(swaps, extensions, { now: NOW });
+    expect(result.results[0].extensionMs).toBe(ONE_HOUR);
+    expect(result.results[1].extensionMs).toBe(ONE_DAY);
+  });
+
+  test("totalExtensionMs sums all extensions", () => {
+    const swaps = [pendingSwap("d1"), pendingSwap("d2")];
+    const result = extendBatchExpiry(swaps, ONE_HOUR, { now: NOW });
+    expect(result.totalExtensionMs).toBe(ONE_HOUR * 2);
+  });
+
+  test("ACTIVE swap is also extendable", () => {
+    const active = { swapId: "act1", state: "ACTIVE", expiresAt: new Date(NOW + ONE_DAY).toISOString() };
+    const result = extendBatchExpiry([active], ONE_HOUR, { now: NOW });
+    expect(result.extendedCount).toBe(1);
+  });
+});
+
+describe("extendBatchExpiry — mixed batch", () => {
+  test("processes valid and invalid items, counts correctly", () => {
+    const swaps = [
+      pendingSwap("m1"),
+      { swapId: "m2", state: "COMPLETED", expiresAt: new Date(NOW + ONE_DAY).toISOString() },
+    ];
+    const result = extendBatchExpiry(swaps, ONE_HOUR, { now: NOW });
+    expect(result.extendedCount).toBe(1);
+    expect(result.failedCount).toBe(1);
+  });
+});

--- a/src/batch/batchExpiryExtender.js
+++ b/src/batch/batchExpiryExtender.js
@@ -1,0 +1,134 @@
+/**
+ * Swap Batch Expiry Extension
+ * ────────────────────────────
+ * Extends the expiry timestamp for multiple swaps in one batch operation.
+ *
+ * Rules:
+ *  - Only PENDING or ACTIVE swaps can be extended
+ *  - Extension must be a positive duration
+ *  - New expiry must not exceed MAX_EXPIRY_EXTENSION_MS from now
+ *  - Already EXPIRED swaps are recorded as errors (non-throwing)
+ */
+
+const EXTENDABLE_STATES    = new Set(["PENDING", "ACTIVE"]);
+const MAX_EXTENSION_MS     = 30 * 24 * 60 * 60 * 1000; // 30 days
+const MIN_EXTENSION_MS     = 60 * 1000;                 // 1 minute
+const MAX_BATCH_SIZE       = 100;
+
+// ── Validators ────────────────────────────────────────────────────────────────
+
+function validateSwap(swap, index) {
+  if (!swap || typeof swap !== "object")
+    throw new TypeError(`Swap at index ${index} must be an object.`);
+  if (!swap.swapId)
+    throw new TypeError(`Swap at index ${index}: swapId is required.`);
+  if (!swap.expiresAt || isNaN(Date.parse(swap.expiresAt)))
+    throw new TypeError(`Swap ${swap.swapId}: expiresAt must be a valid ISO date string.`);
+  if (!swap.state)
+    throw new TypeError(`Swap ${swap.swapId}: state is required.`);
+}
+
+function validateExtension(extension, swap) {
+  if (typeof extension !== "number" || extension <= 0)
+    throw new RangeError(`Swap ${swap.swapId}: extensionMs must be a positive number.`);
+  if (extension < MIN_EXTENSION_MS)
+    throw new RangeError(
+      `Swap ${swap.swapId}: extensionMs must be at least ${MIN_EXTENSION_MS}ms (1 minute).`
+    );
+  if (extension > MAX_EXTENSION_MS)
+    throw new RangeError(
+      `Swap ${swap.swapId}: extensionMs must not exceed ${MAX_EXTENSION_MS}ms (30 days).`
+    );
+}
+
+// ── Core logic ────────────────────────────────────────────────────────────────
+
+function extendOne(swap, extensionMs, now) {
+  if (!EXTENDABLE_STATES.has(swap.state)) {
+    throw new Error(
+      `Swap ${swap.swapId}: only PENDING or ACTIVE swaps can be extended (got '${swap.state}').`
+    );
+  }
+
+  const currentExpiry = new Date(swap.expiresAt).getTime();
+  const baseTime     = Math.max(currentExpiry, now);
+  const newExpiryMs  = baseTime + extensionMs;
+  const newExpiresAt = new Date(newExpiryMs).toISOString();
+
+  return {
+    swapId:          swap.swapId,
+    state:           swap.state,
+    previousExpiry:  swap.expiresAt,
+    newExpiry:       newExpiresAt,
+    extensionMs,
+    extendedAt:      new Date(now).toISOString(),
+  };
+}
+
+// ── Batch entry point ─────────────────────────────────────────────────────────
+
+/**
+ * Extend expiry for a batch of swaps.
+ *
+ * @param {Array<SwapEntry>} swaps
+ * @param {Array<number>|number} extensions  - per-swap extensionMs OR single value applied to all
+ * @param {{ now?: number }} [options]
+ * @returns {BatchExpiryResult}
+ *
+ * @typedef {{ swapId: string, expiresAt: string, state: string }} SwapEntry
+ *
+ * @typedef {Object} BatchExpiryResult
+ * @property {number} batchSize
+ * @property {number} extendedCount
+ * @property {number} failedCount
+ * @property {number} totalExtensionMs
+ * @property {Array}  results
+ * @property {Array}  errors
+ */
+function extendBatchExpiry(swaps, extensions, options = {}) {
+  if (!Array.isArray(swaps) || swaps.length === 0)
+    throw new TypeError("swaps must be a non-empty array.");
+  if (swaps.length > MAX_BATCH_SIZE)
+    throw new RangeError(`Batch size ${swaps.length} exceeds maximum of ${MAX_BATCH_SIZE}.`);
+
+  const now = options.now ?? Date.now();
+
+  const extensionArr = typeof extensions === "number"
+    ? Array(swaps.length).fill(extensions)
+    : extensions;
+
+  if (!Array.isArray(extensionArr) || extensionArr.length !== swaps.length)
+    throw new TypeError("extensions must be a number or an array matching swaps length.");
+
+  const results = [];
+  const errors  = [];
+
+  for (let i = 0; i < swaps.length; i++) {
+    try {
+      validateSwap(swaps[i], i);
+      validateExtension(extensionArr[i], swaps[i]);
+      results.push(extendOne(swaps[i], extensionArr[i], now));
+    } catch (err) {
+      errors.push({ index: i, swapId: swaps[i]?.swapId ?? null, error: err.message });
+    }
+  }
+
+  const totalExtensionMs = results.reduce((s, r) => s + r.extensionMs, 0);
+
+  return {
+    batchSize:        swaps.length,
+    extendedCount:    results.length,
+    failedCount:      errors.length,
+    totalExtensionMs,
+    results,
+    errors,
+  };
+}
+
+module.exports = {
+  extendBatchExpiry,
+  EXTENDABLE_STATES,
+  MAX_EXTENSION_MS,
+  MIN_EXTENSION_MS,
+  MAX_BATCH_SIZE,
+};


### PR DESCRIPTION
## Summary
Extends expiry timestamps for multiple swaps in one batch call with per-item or uniform extension amounts.

## Changes
- \`src/batch/batchExpiryExtender.js\`: \`extendBatchExpiry(swaps, extensions, options)\`
  - Extendable states: PENDING, ACTIVE only
  - \`extensions\`: single \`number\` (applied to all) or array matching swaps length
  - Extends from \`max(currentExpiry, now)\` — no penalty for near-expired swaps
  - Limits: min 1 min, max 30 days per extension; max 100 swaps per batch
  - Per-item error capture (non-throwing) with \`{ index, swapId, error }\`
- \`src/__tests__/batchExpiryExtender.test.js\`: 10 tests — limits, state guards, single/array extensions, ACTIVE state, mixed batch
- \`docs/swap-batch-expiry-extension.md\`: rules table, usage examples

Closes #500