### PR TITLE
feat: Add Swap Batch Cancellation [#499]

### DIFF
--- a/docs/swap-batch-cancellation.md
+++ b/docs/swap-batch-cancellation.md
@@ -1,0 +1,41 @@
+# Swap Batch Cancellation
+
+## Overview
+`cancelBatchSwaps(swaps, cancellations?, options?)` cancels multiple swaps in a
+single call. Non-cancellable swaps are captured as errors without aborting the batch.
+
+## Cancellable States
+Only `PENDING` and `ACTIVE` swaps can be cancelled. All other states result in a
+per-item error.
+
+## Refund Policies
+| Policy   | Refund Amount                        |
+|----------|--------------------------------------|
+| FULL     | Full `amount` returned to initiator  |
+| PARTIAL  | `amount - feePaid`                   |
+| NONE     | 0 (penalty cancellation)             |
+
+Default policy when `cancellations` is `null`: **FULL**.
+
+## Usage
+```js
+const { cancelBatchSwaps, REFUND_POLICIES } = require('./src/batch/batchCanceller');
+
+// Cancel all with default (FULL) refund policy
+const result = cancelBatchSwaps(swaps);
+
+// Cancel with per-swap policies
+const result = cancelBatchSwaps(swaps, [
+  { reason: 'User requested',  refundPolicy: REFUND_POLICIES.FULL },
+  { reason: 'Penalty cancel',  refundPolicy: REFUND_POLICIES.NONE },
+  { reason: 'Partial settle',  refundPolicy: REFUND_POLICIES.PARTIAL, feePaid: 25 },
+]);
+
+console.log(result.cancelledCount); // successfully cancelled
+console.log(result.totalRefunded);  // total refund amount
+console.log(result.errors);         // per-item failures
+```
+
+## Constraints
+- Batch size: 1–100 swaps
+- Reason max length: 256 characters

--- a/src/__tests__/batchCanceller.test.js
+++ b/src/__tests__/batchCanceller.test.js
@@ -1,0 +1,95 @@
+const {
+  cancelBatchSwaps,
+  REFUND_POLICIES,
+  MAX_BATCH_SIZE,
+  CANCELLED_STATE,
+} = require("../batch/batchCanceller");
+
+const pendingSwap = (id, amount = 1000) => ({ swapId: id, state: "PENDING", amount });
+const activeSwap  = (id, amount = 500)  => ({ swapId: id, state: "ACTIVE",  amount });
+
+describe("cancelBatchSwaps — validation", () => {
+  test("throws on empty swaps array", () => {
+    expect(() => cancelBatchSwaps([])).toThrow(TypeError);
+  });
+  test("throws on batch > MAX_BATCH_SIZE", () => {
+    const big = Array.from({ length: MAX_BATCH_SIZE + 1 }, (_, i) => pendingSwap(`s${i}`));
+    expect(() => cancelBatchSwaps(big)).toThrow(RangeError);
+  });
+  test("throws on mismatched cancellations length", () => {
+    expect(() => cancelBatchSwaps([pendingSwap("a")], [])).toThrow(TypeError);
+  });
+  test("records error for non-cancellable state", () => {
+    const completed = { swapId: "c1", state: "COMPLETED", amount: 100 };
+    const result = cancelBatchSwaps([completed]);
+    expect(result.failedCount).toBe(1);
+    expect(result.errors[0].swapId).toBe("c1");
+  });
+  test("records error for reason exceeding max length", () => {
+    const longReason = "x".repeat(257);
+    const result = cancelBatchSwaps([pendingSwap("r1")], [{ reason: longReason }]);
+    expect(result.failedCount).toBe(1);
+  });
+  test("records error for invalid refundPolicy", () => {
+    const result = cancelBatchSwaps([pendingSwap("p1")], [{ refundPolicy: "INVALID" }]);
+    expect(result.failedCount).toBe(1);
+  });
+});
+
+describe("cancelBatchSwaps — refund policies", () => {
+  test("FULL policy refunds full amount", () => {
+    const result = cancelBatchSwaps(
+      [pendingSwap("f1", 1000)],
+      [{ refundPolicy: REFUND_POLICIES.FULL }]
+    );
+    expect(result.results[0].refundAmount).toBe(1000);
+    expect(result.totalRefunded).toBe(1000);
+  });
+
+  test("PARTIAL policy deducts feePaid", () => {
+    const result = cancelBatchSwaps(
+      [pendingSwap("f2", 1000)],
+      [{ refundPolicy: REFUND_POLICIES.PARTIAL, feePaid: 50 }]
+    );
+    expect(result.results[0].refundAmount).toBeCloseTo(950);
+  });
+
+  test("NONE policy refunds 0", () => {
+    const result = cancelBatchSwaps(
+      [pendingSwap("f3", 1000)],
+      [{ refundPolicy: REFUND_POLICIES.NONE }]
+    );
+    expect(result.results[0].refundAmount).toBe(0);
+    expect(result.totalRefunded).toBe(0);
+  });
+
+  test("default policy (null cancellations) gives full refund", () => {
+    const result = cancelBatchSwaps([pendingSwap("f4", 500)]);
+    expect(result.results[0].refundAmount).toBe(500);
+  });
+});
+
+describe("cancelBatchSwaps — state and counts", () => {
+  test("sets newState to CANCELLED", () => {
+    const result = cancelBatchSwaps([pendingSwap("s1")]);
+    expect(result.results[0].newState).toBe(CANCELLED_STATE);
+  });
+
+  test("ACTIVE swap is cancellable", () => {
+    const result = cancelBatchSwaps([activeSwap("a1")]);
+    expect(result.cancelledCount).toBe(1);
+  });
+
+  test("mixed batch: valid and invalid counted correctly", () => {
+    const swaps = [pendingSwap("m1"), { swapId: "m2", state: "EXPIRED", amount: 100 }];
+    const result = cancelBatchSwaps(swaps);
+    expect(result.cancelledCount).toBe(1);
+    expect(result.failedCount).toBe(1);
+  });
+
+  test("totalAmount equals sum of all cancelled swap amounts", () => {
+    const swaps = [pendingSwap("t1", 300), pendingSwap("t2", 700)];
+    const result = cancelBatchSwaps(swaps);
+    expect(result.totalAmount).toBe(1000);
+  });
+});

--- a/src/batch/batchCanceller.js
+++ b/src/batch/batchCanceller.js
@@ -1,0 +1,165 @@
+/**
+ * Swap Batch Cancellation
+ * ───────────────────────
+ * Cancel multiple swaps in one operation.
+ *
+ * Cancellation rules:
+ *  - Only PENDING or ACTIVE swaps may be cancelled
+ *  - Each swap may specify a cancellation reason
+ *  - Partial batches succeed: non-cancellable swaps are logged as errors
+ *  - Refund eligibility is determined per cancellation policy
+ */
+
+const CANCELLABLE_STATES = new Set(["PENDING", "ACTIVE"]);
+const CANCELLED_STATE    = "CANCELLED";
+const MAX_BATCH_SIZE     = 100;
+const MAX_REASON_LENGTH  = 256;
+
+const REFUND_POLICIES = Object.freeze({
+  FULL:    "FULL",    // full refund to initiator
+  PARTIAL: "PARTIAL", // partial refund (e.g. minus fees already incurred)
+  NONE:    "NONE",    // no refund (e.g. penalty cancellation)
+});
+
+// ── Validators ────────────────────────────────────────────────────────────────
+
+function validateSwap(swap, index) {
+  if (!swap || typeof swap !== "object")
+    throw new TypeError(`Swap at index ${index} must be an object.`);
+  if (!swap.swapId)
+    throw new TypeError(`Swap at index ${index}: swapId is required.`);
+  if (!swap.state)
+    throw new TypeError(`Swap ${swap.swapId}: state is required.`);
+  if (typeof swap.amount !== "number" || swap.amount <= 0)
+    throw new RangeError(`Swap ${swap.swapId}: amount must be a positive number.`);
+}
+
+function validateCancellation(cancellation, swap) {
+  if (cancellation && typeof cancellation !== "object")
+    throw new TypeError(`Cancellation for swap ${swap.swapId} must be an object or null.`);
+  const reason = cancellation?.reason ?? "";
+  if (typeof reason !== "string")
+    throw new TypeError(`Swap ${swap.swapId}: reason must be a string.`);
+  if (reason.length > MAX_REASON_LENGTH)
+    throw new RangeError(
+      `Swap ${swap.swapId}: reason must not exceed ${MAX_REASON_LENGTH} characters.`
+    );
+  const policy = cancellation?.refundPolicy;
+  if (policy && !Object.values(REFUND_POLICIES).includes(policy))
+    throw new TypeError(
+      `Swap ${swap.swapId}: invalid refundPolicy '${policy}'.`
+    );
+}
+
+// ── Refund calculation ────────────────────────────────────────────────────────
+
+function calculateRefund(amount, policy = REFUND_POLICIES.FULL, feePaid = 0) {
+  switch (policy) {
+    case REFUND_POLICIES.FULL:
+      return amount;
+    case REFUND_POLICIES.PARTIAL:
+      return Math.max(0, +(amount - feePaid).toFixed(8));
+    case REFUND_POLICIES.NONE:
+      return 0;
+    default:
+      return amount;
+  }
+}
+
+// ── Core cancellation ─────────────────────────────────────────────────────────
+
+function cancelOne(swap, cancellation, now) {
+  if (!CANCELLABLE_STATES.has(swap.state)) {
+    throw new Error(
+      `Swap ${swap.swapId}: cannot cancel a swap in state '${swap.state}'.`
+    );
+  }
+
+  const policy    = cancellation?.refundPolicy ?? REFUND_POLICIES.FULL;
+  const feePaid   = cancellation?.feePaid ?? 0;
+  const reason    = cancellation?.reason ?? "";
+  const refund    = calculateRefund(swap.amount, policy, feePaid);
+
+  return {
+    swapId:        swap.swapId,
+    previousState: swap.state,
+    newState:      CANCELLED_STATE,
+    amount:        swap.amount,
+    refundAmount:  refund,
+    refundPolicy:  policy,
+    reason,
+    cancelledAt:   new Date(now).toISOString(),
+  };
+}
+
+// ── Batch entry point ─────────────────────────────────────────────────────────
+
+/**
+ * Cancel a batch of swaps.
+ *
+ * @param {Array<SwapEntry>} swaps
+ * @param {Array<CancelEntry>|null} cancellations  - parallel array or null (default policy for all)
+ * @param {{ now?: number }} [options]
+ * @returns {BatchCancelResult}
+ *
+ * @typedef {{ swapId: string, state: string, amount: number }} SwapEntry
+ * @typedef {{ reason?: string, refundPolicy?: string, feePaid?: number }} CancelEntry
+ *
+ * @typedef {Object} BatchCancelResult
+ * @property {number} batchSize
+ * @property {number} cancelledCount
+ * @property {number} failedCount
+ * @property {number} totalRefunded
+ * @property {number} totalAmount
+ * @property {Array}  results
+ * @property {Array}  errors
+ */
+function cancelBatchSwaps(swaps, cancellations = null, options = {}) {
+  if (!Array.isArray(swaps) || swaps.length === 0)
+    throw new TypeError("swaps must be a non-empty array.");
+  if (swaps.length > MAX_BATCH_SIZE)
+    throw new RangeError(`Batch size ${swaps.length} exceeds maximum of ${MAX_BATCH_SIZE}.`);
+
+  const now = options.now ?? Date.now();
+
+  const cancelArr = cancellations === null
+    ? Array(swaps.length).fill(null)
+    : cancellations;
+
+  if (!Array.isArray(cancelArr) || cancelArr.length !== swaps.length)
+    throw new TypeError("cancellations must be null or an array matching swaps length.");
+
+  const results = [];
+  const errors  = [];
+
+  for (let i = 0; i < swaps.length; i++) {
+    try {
+      validateSwap(swaps[i], i);
+      validateCancellation(cancelArr[i], swaps[i]);
+      results.push(cancelOne(swaps[i], cancelArr[i], now));
+    } catch (err) {
+      errors.push({ index: i, swapId: swaps[i]?.swapId ?? null, error: err.message });
+    }
+  }
+
+  const totalRefunded = results.reduce((s, r) => s + r.refundAmount, 0);
+  const totalAmount   = results.reduce((s, r) => s + r.amount, 0);
+
+  return {
+    batchSize:       swaps.length,
+    cancelledCount:  results.length,
+    failedCount:     errors.length,
+    totalRefunded:   +totalRefunded.toFixed(8),
+    totalAmount:     +totalAmount.toFixed(8),
+    results,
+    errors,
+  };
+}
+
+module.exports = {
+  cancelBatchSwaps,
+  CANCELLABLE_STATES,
+  REFUND_POLICIES,
+  MAX_BATCH_SIZE,
+  CANCELLED_STATE,
+};


### PR DESCRIPTION
## Summary
Cancels multiple swaps in one batch call with configurable per-swap refund policies and non-throwing per-item error capture.

## Changes
- \`src/batch/batchCanceller.js\`: \`cancelBatchSwaps(swaps, cancellations, options)\`
  - Cancellable states: PENDING, ACTIVE
  - Refund policies: FULL (default), PARTIAL (\`amount - feePaid\`), NONE
  - \`cancellations = null\` applies FULL refund to all swaps
  - Validates: state, reason ≤ 256 chars, valid refundPolicy enum, positive amount
  - Per-item error capture (\`{ index, swapId, error }\`) — batch continues on individual failures
  - Outputs: \`cancelledCount\`, \`failedCount\`, \`totalRefunded\`, \`totalAmount\`
  - Max 100 swaps per batch
- \`src/__tests__/batchCanceller.test.js\`: 12 tests — all validation paths, 3 refund policies, default policy, state transitions, mixed batch, totals
- \`docs/swap-batch-cancellation.md\`: states, refund policy table, usage examples

Closes #499