### PR TITLE
feat: Add Swap Reputation Scoring [#474]

### DIFF
--- a/docs/swap-reputation-scoring.md
+++ b/docs/swap-reputation-scoring.md
@@ -1,0 +1,37 @@
+# Swap Reputation Scoring
+
+## Overview
+`calculateReputationScore(input)` produces a 0–1000 reputation score for any
+swap participant based on their historical swap behaviour.
+
+## Score Factors
+
+| Factor            | Range        | Description                                    |
+|-------------------|--------------|------------------------------------------------|
+| Completion rate   | 0 – 200 pts  | Completed / initiated swaps                    |
+| Dispute penalty   | -150 – 0 pts | Dispute rate on completed swaps                |
+| Weighted rating   | 0 – 300 pts  | 1–5 star avg, recency-weighted (90d half-life) |
+| Tenure bonus      | 0 – 100 pts  | Log-scale up to 2 years                        |
+| Volume bonus      | 0 – 100 pts  | √n scale up to 200 swaps                      |
+| Cancellation pen. | -150 – 0 pts | Recency-weighted cancellation count            |
+
+## Tiers
+| Score    | Tier     |
+|----------|----------|
+| 850–1000 | Platinum |
+| 700–849  | Gold     |
+| 550–699  | Silver   |
+| 400–549  | Bronze   |
+| < 400    | New      |
+
+## Usage
+```js
+const { calculateReputationScore } = require('./src/reputation/swapReputationScorer');
+
+const result = calculateReputationScore({
+  participantId: 'user-42',
+  accountCreatedAt: '2022-01-01',
+  history: [ /* HistoryEntry[] */ ],
+});
+console.log(result.score, result.tier);
+```

--- a/src/__tests__/swapReputationScorer.test.js
+++ b/src/__tests__/swapReputationScorer.test.js
@@ -1,0 +1,108 @@
+const {
+  calculateReputationScore,
+  batchCalculateReputation,
+  recencyWeight,
+  scoreTier,
+  STARTING_SCORE,
+} = require("../reputation/swapReputationScorer");
+
+const NOW = new Date("2024-06-01T00:00:00.000Z").getTime();
+const daysAgo = (d) => new Date(NOW - d * 86_400_000).toISOString();
+
+const makeHistory = (count, outcome = "completed", extras = {}) =>
+  Array.from({ length: count }, (_, i) => ({
+    outcome,
+    role: "initiator",
+    date: daysAgo(i * 5),
+    rating: 5,
+    disputed: false,
+    ...extras,
+  }));
+
+describe("recencyWeight", () => {
+  test("weight is 1.0 for today", () => {
+    expect(recencyWeight(NOW, NOW)).toBeCloseTo(1.0, 4);
+  });
+  test("weight is ~0.5 at half-life", () => {
+    expect(recencyWeight(NOW - 90 * 86_400_000, NOW)).toBeCloseTo(0.5, 1);
+  });
+  test("weight approaches 0 for very old events", () => {
+    expect(recencyWeight(NOW - 3650 * 86_400_000, NOW)).toBeLessThan(0.01);
+  });
+});
+
+describe("scoreTier", () => {
+  test.each([
+    [900, "platinum"], [750, "gold"], [600, "silver"],
+    [450, "bronze"],   [200, "new"],
+  ])("score %d → tier %s", (score, tier) => {
+    expect(scoreTier(score)).toBe(tier);
+  });
+});
+
+describe("calculateReputationScore", () => {
+  test("throws on missing participantId", () => {
+    expect(() => calculateReputationScore({ history: [] })).toThrow(TypeError);
+  });
+
+  test("new participant with no history starts at STARTING_SCORE", () => {
+    const { score } = calculateReputationScore({ participantId: "p1", history: [] }, NOW);
+    expect(score).toBe(STARTING_SCORE);
+  });
+
+  test("perfect history (completed, 5-star) scores high", () => {
+    const history = makeHistory(20);
+    const { score, tier } = calculateReputationScore(
+      { participantId: "p1", history, accountCreatedAt: daysAgo(365) },
+      NOW
+    );
+    expect(score).toBeGreaterThan(800);
+    expect(["gold", "platinum"]).toContain(tier);
+  });
+
+  test("high dispute rate penalises score", () => {
+    const history = makeHistory(20, "completed", { disputed: true });
+    const { score: disputed } = calculateReputationScore({ participantId: "p1", history }, NOW);
+    const { score: clean } = calculateReputationScore({ participantId: "p1", history: makeHistory(20) }, NOW);
+    expect(disputed).toBeLessThan(clean);
+  });
+
+  test("cancellations penalise score", () => {
+    const { score: cs } = calculateReputationScore({ participantId: "p1", history: makeHistory(10, "cancelled") }, NOW);
+    const { score: co } = calculateReputationScore({ participantId: "p1", history: makeHistory(10) }, NOW);
+    expect(cs).toBeLessThan(co);
+  });
+
+  test("dampened flag set for < 10 swaps", () => {
+    const { dampened } = calculateReputationScore(
+      { participantId: "p1", history: makeHistory(5) },
+      NOW
+    );
+    expect(dampened).toBe(true);
+  });
+
+  test("score is clamped between 0 and 1000", () => {
+    const bad = Array.from({ length: 50 }, (_, i) => ({
+      outcome: "cancelled", role: "initiator", date: daysAgo(i),
+      rating: 1, disputed: true,
+    }));
+    const { score } = calculateReputationScore({ participantId: "bad", history: bad }, NOW);
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(1000);
+  });
+});
+
+describe("batchCalculateReputation", () => {
+  test("returns results sorted by score descending", () => {
+    const inputs = [
+      { participantId: "low", history: makeHistory(5, "cancelled") },
+      { participantId: "high", history: makeHistory(20) },
+    ];
+    const results = batchCalculateReputation(inputs, NOW);
+    expect(results[0].participantId).toBe("high");
+  });
+
+  test("throws on empty input", () => {
+    expect(() => batchCalculateReputation([])).toThrow(TypeError);
+  });
+});

--- a/src/reputation/swapReputationScorer.js
+++ b/src/reputation/swapReputationScorer.js
@@ -1,0 +1,140 @@
+/**
+ * Swap Reputation Scoring — Issue #474
+ * ──────────────────────────────────────
+ * Scores buyers and sellers based on their swap history.
+ *
+ * Score range: 0–1000 (higher = better reputation)
+ * Starting score for new participants: 500
+ *
+ * Scoring factors:
+ *  - Completion rate      (swaps completed / initiated)
+ *  - Dispute rate         (disputes / completed)
+ *  - Average rating       (1–5 stars, weighted by recency)
+ *  - Tenure bonus         (account age in days)
+ *  - Volume bonus         (total swap count)
+ *  - Cancellation penalty (cancelled swaps)
+ */
+
+const STARTING_SCORE     = 500;
+const MAX_SCORE          = 1000;
+const MIN_SCORE          = 0;
+const RECENCY_HALF_LIFE  = 90;
+const MIN_SWAPS_FOR_FULL = 10;
+
+function recencyWeight(eventDateMs, nowMs = Date.now()) {
+  const agedays = (nowMs - eventDateMs) / 86_400_000;
+  return Math.exp((-Math.LN2 * agedays) / RECENCY_HALF_LIFE);
+}
+
+function completionScore(history) {
+  const initiated = history.filter((h) => h.role === "initiator").length;
+  if (initiated === 0) return 100;
+  const completed = history.filter((h) => h.role === "initiator" && h.outcome === "completed").length;
+  return Math.round((completed / initiated) * 200);
+}
+
+function disputePenalty(history) {
+  const completed = history.filter((h) => h.outcome === "completed").length;
+  if (completed === 0) return 0;
+  const disputes  = history.filter((h) => h.disputed === true).length;
+  const rate      = disputes / completed;
+  return -Math.round(Math.min(rate / 0.1, 1) * 150);
+}
+
+function ratingScore(history, nowMs = Date.now()) {
+  const rated = history.filter((h) => h.rating != null && h.rating >= 1 && h.rating <= 5);
+  if (rated.length === 0) return 150;
+
+  let weightedSum = 0, totalWeight = 0;
+  for (const h of rated) {
+    const w = recencyWeight(new Date(h.date).getTime(), nowMs);
+    weightedSum += h.rating * w;
+    totalWeight += w;
+  }
+  const avg = totalWeight > 0 ? weightedSum / totalWeight : 3;
+  return Math.round(((avg - 1) / 4) * 300);
+}
+
+function tenureBonus(accountCreatedAt, nowMs = Date.now()) {
+  if (!accountCreatedAt) return 0;
+  const agedays = (nowMs - new Date(accountCreatedAt).getTime()) / 86_400_000;
+  return Math.round(Math.min(Math.log1p(agedays) / Math.log1p(730), 1) * 100);
+}
+
+function volumeBonus(history) {
+  const count = history.length;
+  return Math.round(Math.min(Math.sqrt(count) / Math.sqrt(200), 1) * 100);
+}
+
+function cancellationPenalty(history, nowMs = Date.now()) {
+  const cancellations = history.filter((h) => h.outcome === "cancelled");
+  if (cancellations.length === 0) return 0;
+  const weightedCancels = cancellations.reduce(
+    (s, h) => s + recencyWeight(new Date(h.date).getTime(), nowMs),
+    0
+  );
+  return -Math.round(Math.min(weightedCancels / 5, 1) * 150);
+}
+
+function scoreTier(score) {
+  if (score >= 850) return "platinum";
+  if (score >= 700) return "gold";
+  if (score >= 550) return "silver";
+  if (score >= 400) return "bronze";
+  return "new";
+}
+
+/**
+ * Calculate reputation score for a participant.
+ *
+ * @param {object} input - { participantId, history, accountCreatedAt? }
+ * @returns {{ participantId, score, tier, breakdown, swapCount, dampened }}
+ */
+function calculateReputationScore(input, nowMs = Date.now()) {
+  const { participantId, history = [], accountCreatedAt } = input;
+  if (!participantId) throw new TypeError("participantId is required.");
+  if (!Array.isArray(history)) throw new TypeError("history must be an array.");
+
+  const breakdown = {
+    completion:   completionScore(history),
+    dispute:      disputePenalty(history),
+    rating:       ratingScore(history, nowMs),
+    tenure:       tenureBonus(accountCreatedAt, nowMs),
+    volume:       volumeBonus(history),
+    cancellation: cancellationPenalty(history, nowMs),
+  };
+
+  let raw = Object.values(breakdown).reduce((s, v) => s + v, 0);
+
+  const dampened = history.length < MIN_SWAPS_FOR_FULL;
+  if (dampened) {
+    const weight = history.length / MIN_SWAPS_FOR_FULL;
+    raw = STARTING_SCORE + (raw - STARTING_SCORE) * weight;
+  }
+
+  const score = Math.round(Math.min(MAX_SCORE, Math.max(MIN_SCORE, raw)));
+  const tier  = scoreTier(score);
+
+  return { participantId, score, tier, breakdown, swapCount: history.length, dampened };
+}
+
+/**
+ * Batch score multiple participants, sorted by score descending.
+ */
+function batchCalculateReputation(inputs, nowMs = Date.now()) {
+  if (!Array.isArray(inputs) || inputs.length === 0)
+    throw new TypeError("inputs must be a non-empty array.");
+  return inputs
+    .map((input) => calculateReputationScore(input, nowMs))
+    .sort((a, b) => b.score - a.score);
+}
+
+module.exports = {
+  calculateReputationScore,
+  batchCalculateReputation,
+  recencyWeight,
+  scoreTier,
+  STARTING_SCORE,
+  MAX_SCORE,
+  MIN_SCORE,
+};


### PR DESCRIPTION
## Summary
6-factor reputation scoring system (0–1000) for swap buyers and sellers with recency weighting and tier classification.

## Changes
- `src/reputation/swapReputationScorer.js`: `calculateReputationScore`, `batchCalculateReputation`
  - Completion rate (0–200), dispute penalty (-150–0), recency-weighted rating (0–300, 90d half-life), tenure (0–100 log), volume (0–100 √n), cancellation penalty (-150–0)
  - Score clamped 0–1000; dampened toward 500 for < 10 swaps
  - Tiers: platinum/gold/silver/bronze/new
- `src/__tests__/swapReputationScorer.test.js`: 12 tests — recency decay, tiers, perfect/disputed/cancelled history, damping, clamp, batch sort
- `docs/swap-reputation-scoring.md`: factor table, tier table, usage example

Closes #474