### PR TITLE
feat: Implement Swap Royalty Tracking [#472]

### DIFF
--- a/docs/swap-royalty-tracking.md
+++ b/docs/swap-royalty-tracking.md
@@ -1,0 +1,47 @@
+# Swap Royalty Tracking
+
+## Overview
+`calculateRoyalty(config, salePrice)` computes royalty distributions for IP resale swaps.
+`recordRoyaltyEvent` and `processPayouts` manage a lightweight in-memory ledger.
+
+## Royalty Config
+
+```js
+{
+  assetId: "patent-42",
+  rateBps: 1000,            // 10% (max 3000 = 30%)
+  beneficiaries: [
+    { id: "creator-1", shareBps: 7000 },  // 70% of royalty
+    { id: "agent-1",   shareBps: 3000 },  // 30% of royalty
+    // shareBps must sum to 10000
+  ]
+}
+```
+
+## Ledger Operations
+
+| Function                | Description                                    |
+|-------------------------|------------------------------------------------|
+| `recordRoyaltyEvent`    | Appends PENDING entries for each beneficiary   |
+| `processPayouts`        | Marks PENDING → PAID, respects maxAmount cap   |
+| `getPendingRoyalties`   | Sums unpaid amounts for a beneficiary          |
+| `processBatchRoyalties` | Processes many transactions, collects errors   |
+
+## Usage
+```js
+const {
+  calculateRoyalty,
+  recordRoyaltyEvent,
+  processPayouts,
+  getPendingRoyalties,
+} = require('./src/royalty/swapRoyaltyTracker');
+
+const ledger = [];
+
+const calc    = calculateRoyalty(config, 10_000);
+// => { totalRoyalty: 1000, sellerProceeds: 9000, payouts: [...] }
+
+recordRoyaltyEvent(ledger, 'swap-99', calc);
+processPayouts(ledger, 'creator-1');
+const { total } = getPendingRoyalties(ledger, 'agent-1');
+```

--- a/src/__tests__/swapRoyaltyTracker.test.js
+++ b/src/__tests__/swapRoyaltyTracker.test.js
@@ -1,0 +1,146 @@
+const {
+  calculateRoyalty,
+  recordRoyaltyEvent,
+  processPayouts,
+  getPendingRoyalties,
+  processBatchRoyalties,
+  MAX_ROYALTY_RATE_BPS,
+  BPS_DENOM,
+} = require("../royalty/swapRoyaltyTracker");
+
+const singleBeneficiary = () => ({
+  assetId:       "asset-1",
+  rateBps:       1000, // 10%
+  beneficiaries: [{ id: "creator-1", shareBps: 10_000 }],
+});
+
+const multiConfig = () => ({
+  assetId:       "asset-2",
+  rateBps:       500, // 5%
+  beneficiaries: [
+    { id: "creator-1", shareBps: 7_000 },
+    { id: "agent-1",   shareBps: 3_000 },
+  ],
+});
+
+describe("validateRoyaltyConfig", () => {
+  test("throws on missing assetId", () => {
+    expect(() => calculateRoyalty({ rateBps: 100, beneficiaries: [{ id: "x", shareBps: 10_000 }] }, 1000))
+      .toThrow(TypeError);
+  });
+
+  test("throws if rateBps exceeds max", () => {
+    expect(() => calculateRoyalty({ assetId: "a", rateBps: MAX_ROYALTY_RATE_BPS + 1, beneficiaries: [{ id: "x", shareBps: 10_000 }] }, 1000))
+      .toThrow(RangeError);
+  });
+
+  test("throws if beneficiary shares do not sum to 10000", () => {
+    const config = { assetId: "a", rateBps: 100, beneficiaries: [{ id: "x", shareBps: 5_000 }] };
+    expect(() => calculateRoyalty(config, 1000)).toThrow(RangeError);
+  });
+});
+
+describe("calculateRoyalty", () => {
+  test("calculates correct totalRoyalty and sellerProceeds", () => {
+    const result = calculateRoyalty(singleBeneficiary(), 10_000);
+    expect(result.totalRoyalty).toBe(1_000);
+    expect(result.sellerProceeds).toBe(9_000);
+  });
+
+  test("splits royalty between multiple beneficiaries", () => {
+    const result = calculateRoyalty(multiConfig(), 10_000);
+    expect(result.payouts).toHaveLength(2);
+    const total = result.payouts.reduce((s, p) => s + p.amount, 0);
+    expect(total).toBe(result.totalRoyalty);
+  });
+
+  test("dust assigned to first beneficiary", () => {
+    // 3 beneficiaries splitting 10000bps with 3333/3333/3334 may produce dust
+    const config = {
+      assetId: "a", rateBps: 1000,
+      beneficiaries: [
+        { id: "b1", shareBps: 3334 },
+        { id: "b2", shareBps: 3333 },
+        { id: "b3", shareBps: 3333 },
+      ],
+    };
+    const result = calculateRoyalty(config, 999);
+    const total = result.payouts.reduce((s, p) => s + p.amount, 0);
+    expect(total).toBe(result.totalRoyalty);
+  });
+
+  test("throws on non-positive salePrice", () => {
+    expect(() => calculateRoyalty(singleBeneficiary(), 0)).toThrow(RangeError);
+  });
+});
+
+describe("recordRoyaltyEvent", () => {
+  test("adds entries to ledger", () => {
+    const ledger = [];
+    const calc   = calculateRoyalty(multiConfig(), 5_000);
+    const entries = recordRoyaltyEvent(ledger, "swap-1", calc);
+    expect(ledger).toHaveLength(2);
+    expect(entries.every((e) => e.status === "PENDING")).toBe(true);
+  });
+
+  test("throws on missing swapId", () => {
+    expect(() => recordRoyaltyEvent([], "", calculateRoyalty(singleBeneficiary(), 1000))).toThrow(TypeError);
+  });
+});
+
+describe("processPayouts", () => {
+  test("marks matching PENDING entries as PAID", () => {
+    const ledger = [];
+    recordRoyaltyEvent(ledger, "swap-1", calculateRoyalty(singleBeneficiary(), 10_000));
+    const { paid, totalPaid } = processPayouts(ledger, "creator-1");
+    expect(paid).toHaveLength(1);
+    expect(totalPaid).toBe(1_000);
+    expect(ledger[0].status).toBe("PAID");
+  });
+
+  test("respects maxAmount cap", () => {
+    const ledger = [];
+    recordRoyaltyEvent(ledger, "swap-1", calculateRoyalty(singleBeneficiary(), 10_000));
+    recordRoyaltyEvent(ledger, "swap-2", calculateRoyalty(singleBeneficiary(), 10_000));
+    const { paid } = processPayouts(ledger, "creator-1", { maxAmount: 1_500 });
+    expect(paid).toHaveLength(1);
+  });
+});
+
+describe("getPendingRoyalties", () => {
+  test("returns correct pending total", () => {
+    const ledger = [];
+    recordRoyaltyEvent(ledger, "swap-1", calculateRoyalty(singleBeneficiary(), 10_000));
+    const { total } = getPendingRoyalties(ledger, "creator-1");
+    expect(total).toBe(1_000);
+  });
+});
+
+describe("processBatchRoyalties", () => {
+  test("processes multiple transactions and records to ledger", () => {
+    const ledger = [];
+    const txs = [
+      { config: singleBeneficiary(), salePrice: 10_000, swapId: "s1" },
+      { config: multiConfig(),       salePrice: 5_000,  swapId: "s2" },
+    ];
+    const result = processBatchRoyalties(txs, ledger);
+    expect(result.processed).toBe(2);
+    expect(result.failed).toBe(0);
+    expect(result.totalRoyaltiesGenerated).toBeGreaterThan(0);
+  });
+
+  test("records errors without aborting batch", () => {
+    const ledger = [];
+    const txs = [
+      { config: singleBeneficiary(), salePrice: 10_000, swapId: "s1" },
+      { config: { assetId: "bad", rateBps: -1, beneficiaries: [] }, salePrice: 100, swapId: "s2" },
+    ];
+    const result = processBatchRoyalties(txs, ledger);
+    expect(result.processed).toBe(1);
+    expect(result.failed).toBe(1);
+  });
+
+  test("throws on empty transactions", () => {
+    expect(() => processBatchRoyalties([], [])).toThrow(TypeError);
+  });
+});

--- a/src/royalty/swapRoyaltyTracker.js
+++ b/src/royalty/swapRoyaltyTracker.js
@@ -1,0 +1,178 @@
+/**
+ * Swap Royalty Tracking — Issue #472
+ * ─────────────────────────────────────
+ * Tracks and distributes royalties from IP resales.
+ *
+ * Model:
+ *  - Each IP asset has a royalty configuration: beneficiary(s) + rate
+ *  - Every resale swap triggers a royalty calculation
+ *  - Royalties split pro-rata among multiple beneficiaries
+ *  - Distribution ledger tracks pending and paid royalties
+ */
+
+const MAX_ROYALTY_RATE_BPS = 3000;
+const BPS_DENOM            = 10_000;
+const MAX_BENEFICIARIES    = 10;
+
+function validateRoyaltyConfig(config) {
+  if (!config || typeof config !== "object")
+    throw new TypeError("royaltyConfig must be an object.");
+  if (!config.assetId)
+    throw new TypeError("royaltyConfig: assetId is required.");
+  if (typeof config.rateBps !== "number" || config.rateBps < 0 || config.rateBps > MAX_ROYALTY_RATE_BPS)
+    throw new RangeError(`rateBps must be between 0 and ${MAX_ROYALTY_RATE_BPS}.`);
+  if (!Array.isArray(config.beneficiaries) || config.beneficiaries.length === 0)
+    throw new TypeError("beneficiaries must be a non-empty array.");
+  if (config.beneficiaries.length > MAX_BENEFICIARIES)
+    throw new RangeError(`Maximum ${MAX_BENEFICIARIES} beneficiaries per asset.`);
+
+  const totalShare = config.beneficiaries.reduce((s, b) => s + (b.shareBps ?? 0), 0);
+  if (Math.abs(totalShare - BPS_DENOM) > 1)
+    throw new RangeError(`Beneficiary shares must sum to ${BPS_DENOM} bps (got ${totalShare}).`);
+}
+
+/**
+ * Calculate royalty amounts for a single resale transaction.
+ *
+ * @param {object} config  - { assetId, rateBps, beneficiaries: [{ id, shareBps }] }
+ * @param {number} salePrice
+ * @returns {{ assetId, salePrice, totalRoyalty, rateBps, payouts, sellerProceeds }}
+ */
+function calculateRoyalty(config, salePrice) {
+  validateRoyaltyConfig(config);
+  if (typeof salePrice !== "number" || salePrice <= 0)
+    throw new RangeError("salePrice must be a positive number.");
+
+  const totalRoyalty = Math.floor((salePrice * config.rateBps) / BPS_DENOM);
+
+  const payouts = config.beneficiaries.map((b) => ({
+    beneficiaryId: b.id,
+    shareBps:      b.shareBps,
+    amount:        Math.floor((totalRoyalty * b.shareBps) / BPS_DENOM),
+  }));
+
+  // Dust (rounding residual) → first beneficiary
+  const distributedTotal = payouts.reduce((s, p) => s + p.amount, 0);
+  if (distributedTotal < totalRoyalty) {
+    payouts[0].amount += totalRoyalty - distributedTotal;
+  }
+
+  return {
+    assetId:        config.assetId,
+    salePrice,
+    totalRoyalty,
+    rateBps:        config.rateBps,
+    payouts,
+    sellerProceeds: salePrice - totalRoyalty,
+  };
+}
+
+/**
+ * Record a royalty event to the distribution ledger.
+ *
+ * @param {object[]} ledger  - mutable array (in-memory)
+ * @param {string}   swapId
+ * @param {object}   calculation  - result of calculateRoyalty
+ * @returns {object[]} new ledger entries
+ */
+function recordRoyaltyEvent(ledger, swapId, calculation) {
+  if (!Array.isArray(ledger)) throw new TypeError("ledger must be an array.");
+  if (!swapId) throw new TypeError("swapId is required.");
+
+  const createdAt = new Date().toISOString();
+  const entries   = calculation.payouts.map((p, i) => ({
+    entryId:       `${swapId}-${calculation.assetId}-${i}`,
+    swapId,
+    assetId:       calculation.assetId,
+    beneficiaryId: p.beneficiaryId,
+    amount:        p.amount,
+    status:        "PENDING",
+    createdAt,
+  }));
+
+  ledger.push(...entries);
+  return entries;
+}
+
+/**
+ * Mark PENDING ledger entries as PAID for a beneficiary.
+ *
+ * @param {object[]} ledger
+ * @param {string}   beneficiaryId
+ * @param {{ maxAmount?: number }} [options]
+ * @returns {{ paid: object[], totalPaid: number }}
+ */
+function processPayouts(ledger, beneficiaryId, options = {}) {
+  if (!beneficiaryId) throw new TypeError("beneficiaryId is required.");
+  const maxAmount = options.maxAmount ?? Infinity;
+
+  let remaining = maxAmount;
+  const paid = [];
+
+  for (const entry of ledger) {
+    if (entry.beneficiaryId !== beneficiaryId) continue;
+    if (entry.status !== "PENDING")            continue;
+    if (entry.amount > remaining)              break;
+
+    entry.status = "PAID";
+    entry.paidAt = new Date().toISOString();
+    paid.push(entry);
+    remaining -= entry.amount;
+  }
+
+  return { paid, totalPaid: paid.reduce((s, e) => s + e.amount, 0) };
+}
+
+/**
+ * Query pending royalties owed to a beneficiary.
+ */
+function getPendingRoyalties(ledger, beneficiaryId) {
+  const entries = ledger.filter(
+    (e) => e.beneficiaryId === beneficiaryId && e.status === "PENDING"
+  );
+  return { beneficiaryId, entries, total: entries.reduce((s, e) => s + e.amount, 0) };
+}
+
+/**
+ * Batch: calculate and record royalties for multiple resale transactions.
+ *
+ * @param {Array<{ config, salePrice, swapId }>} transactions
+ * @param {object[]} ledger
+ * @returns {{ processed, failed, totalRoyaltiesGenerated, results, errors }}
+ */
+function processBatchRoyalties(transactions, ledger) {
+  if (!Array.isArray(transactions) || transactions.length === 0)
+    throw new TypeError("transactions must be a non-empty array.");
+
+  const results = [];
+  const errors  = [];
+
+  for (const tx of transactions) {
+    try {
+      const calc    = calculateRoyalty(tx.config, tx.salePrice);
+      const entries = recordRoyaltyEvent(ledger, tx.swapId, calc);
+      results.push({ swapId: tx.swapId, calculation: calc, entries });
+    } catch (err) {
+      errors.push({ swapId: tx.swapId, error: err.message });
+    }
+  }
+
+  return {
+    processed:               results.length,
+    failed:                  errors.length,
+    totalRoyaltiesGenerated: results.reduce((s, r) => s + r.calculation.totalRoyalty, 0),
+    results,
+    errors,
+  };
+}
+
+module.exports = {
+  calculateRoyalty,
+  recordRoyaltyEvent,
+  processPayouts,
+  getPendingRoyalties,
+  processBatchRoyalties,
+  validateRoyaltyConfig,
+  MAX_ROYALTY_RATE_BPS,
+  BPS_DENOM,
+};


### PR DESCRIPTION
## Summary
BPS-based royalty calculation and ledger management for IP resale swaps, with multi-beneficiary splits and batch processing.

## Changes
- `src/royalty/swapRoyaltyTracker.js`:
  - `calculateRoyalty`: rate (0–30%) applied in bps, split pro-rata across ≤10 beneficiaries; dust (rounding residual) to first beneficiary
  - `recordRoyaltyEvent`: appends PENDING entries to in-memory ledger
  - `processPayouts`: marks PENDING → PAID, optional `maxAmount` cap
  - `getPendingRoyalties`: returns unpaid entries + total for a beneficiary
  - `processBatchRoyalties`: processes many transactions, collects errors without aborting
- `src/__tests__/swapRoyaltyTracker.test.js`: 14 tests — config validation, royalty math, dust handling, ledger ops, batch error isolation
- `docs/swap-royalty-tracking.md`: config schema, ledger API table, usage example

Closes #472