### PR TITLE
Add batch staking and batch reputation update for IP commitments

### DIFF
--- a/contracts/ip_registry/src/lib.rs
+++ b/contracts/ip_registry/src/lib.rs
@@ -3069,6 +3069,38 @@ impl IpRegistry {
         env.events().publish((symbol_short!("staked"), record.owner), (ip_id, amount));
     }
 
+    /// Stake XLM against multiple IP commitments in one call.
+    /// Each `ip_ids[i]` is staked with `amounts[i]` and requires the owner
+    /// of that IP to authorize the call.
+    pub fn batch_stake_commitments(env: Env, ip_ids: Vec<u64>, amounts: Vec<i128>) {
+        if ip_ids.len() != amounts.len() {
+            env.panic_with_error(Error::from_contract_error(
+                ContractError::BatchSizeMismatch as u32,
+            ));
+        }
+
+        for i in 0..ip_ids.len() {
+            let ip_id = ip_ids.get(i).unwrap();
+            let amount = amounts.get(i).unwrap();
+            let record = require_ip_exists(&env, *ip_id);
+            record.owner.require_auth();
+
+            if env.storage().persistent().has(&DataKey::IpStake(*ip_id)) {
+                panic_with_error!(&env, ContractError::AlreadyStaked);
+            }
+
+            let stake = StakeRecord {
+                ip_id: *ip_id,
+                owner: record.owner.clone(),
+                amount: *amount,
+                slashed: false,
+            };
+            env.storage().persistent().set(&DataKey::IpStake(*ip_id), &stake);
+            env.storage().persistent().extend_ttl(&DataKey::IpStake(*ip_id), LEDGER_BUMP, LEDGER_BUMP);
+            env.events().publish((symbol_short!("staked"), record.owner), (*ip_id, *amount));
+        }
+    }
+
     /// Slash the stake for an IP (admin-only). Marks the stake as slashed and
     /// decrements the owner's reputation score.
     pub fn slash_stake(env: Env, ip_id: u64) {
@@ -3173,6 +3205,45 @@ impl IpRegistry {
         rep.score = rep.score.saturating_add(score_delta);
         env.storage().persistent().set(&DataKey::OwnerReputation(owner.clone()), &rep);
         env.storage().persistent().extend_ttl(&DataKey::OwnerReputation(owner), LEDGER_BUMP, LEDGER_BUMP);
+    }
+
+    /// Adjust reputation for multiple IP commitments in one call.
+    /// Each `ip_ids[i]` is used to lookup the IP owner, then the corresponding
+    /// `score_deltas[i]` is applied to that owner's reputation.
+    pub fn batch_update_reputation(env: Env, ip_ids: Vec<u64>, score_deltas: Vec<i64>) {
+        if ip_ids.len() != score_deltas.len() {
+            env.panic_with_error(Error::from_contract_error(
+                ContractError::BatchSizeMismatch as u32,
+            ));
+        }
+
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::Unauthorized));
+        admin.require_auth();
+
+        for i in 0..ip_ids.len() {
+            let ip_id = ip_ids.get(i).unwrap();
+            let score_delta = score_deltas.get(i).unwrap();
+            let record = require_ip_exists(&env, *ip_id);
+            let owner = record.owner.clone();
+
+            let mut rep: ReputationRecord = env
+                .storage()
+                .persistent()
+                .get(&DataKey::OwnerReputation(owner.clone()))
+                .unwrap_or(ReputationRecord {
+                    owner: owner.clone(),
+                    score: 0,
+                    commitments: 0,
+                    disputes_lost: 0,
+                });
+            rep.score = rep.score.saturating_add(*score_delta);
+            env.storage().persistent().set(&DataKey::OwnerReputation(owner.clone()), &rep);
+            env.storage().persistent().extend_ttl(&DataKey::OwnerReputation(owner), LEDGER_BUMP, LEDGER_BUMP);
+        }
     }
 
     // ── Issue #449: IP Commitment Dispute Arbitration ─────────────────────────

--- a/contracts/ip_registry/src/test.rs
+++ b/contracts/ip_registry/src/test.rs
@@ -22,6 +22,7 @@ mod tests {
             blinding_factor: BytesN<32>,
         ) -> bool;
         fn list_ip_by_owner(env: Env, owner: Address) -> Vec<u64>;
+        fn get_stake(env: Env, ip_id: u64) -> Option<StakeRecord>;
         fn transfer_ip(env: Env, ip_id: u64, new_owner: Address);
         fn transfer_ip_ownership(env: Env, ip_id: u64, new_owner: Address);
         fn revoke_ip(env: Env, ip_id: u64);
@@ -62,6 +63,9 @@ mod tests {
         // Issue #432
         fn batch_verify_commitments(env: Env, verifications: Vec<(u64, BytesN<32>, BytesN<32>)>) -> Vec<bool>;
         fn batch_commit_ip_anonymous(env: Env, blinded_owner: BytesN<32>, commitment_hashes: Vec<BytesN<32>>) -> Vec<u64>;
+        fn batch_stake_commitments(env: Env, ip_ids: Vec<u64>, amounts: Vec<i128>);
+        fn batch_update_reputation(env: Env, ip_ids: Vec<u64>, score_deltas: Vec<i64>);
+        fn get_reputation(env: Env, owner: Address) -> crate::ReputationRecord;
         fn get_anonymous_owner(env: Env, commitment_hash: BytesN<32>) -> Option<BytesN<32>>;
         // Issue #433
         fn issue_ownership_challenge(env: Env, ip_id: u64, challenger: Address, nonce: BytesN<32>) -> u64;
@@ -169,6 +173,123 @@ mod tests {
         assert_eq!(record.commitment_hash, commitment);
         assert_eq!(record.ip_id, ip_id);
         assert_eq!(observed_data.1, record.timestamp);
+    }
+
+    #[test]
+    fn test_batch_stake_commitments_success() {
+        let env = Env::default();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner1 = <Address as TestAddress>::generate(&env);
+        let owner2 = <Address as TestAddress>::generate(&env);
+        let commitment1 = BytesN::from_array(&env, &[11u8; 32]);
+        let commitment2 = BytesN::from_array(&env, &[12u8; 32]);
+
+        env.mock_all_auths();
+        let ip_id1 = client.commit_ip(&owner1, &commitment1, &0u32);
+        let ip_id2 = client.commit_ip(&owner2, &commitment2, &0u32);
+
+        let mut ip_ids = Vec::new(&env);
+        ip_ids.push_back(ip_id1);
+        ip_ids.push_back(ip_id2);
+
+        let mut amounts = Vec::new(&env);
+        amounts.push_back(100i128);
+        amounts.push_back(200i128);
+
+        client.batch_stake_commitments(&ip_ids, &amounts);
+
+        let stake1 = client.get_stake(&ip_id1).unwrap();
+        let stake2 = client.get_stake(&ip_id2).unwrap();
+
+        assert_eq!(stake1.ip_id, ip_id1);
+        assert_eq!(stake1.owner, owner1);
+        assert_eq!(stake1.amount, 100i128);
+        assert!(!stake1.slashed);
+
+        assert_eq!(stake2.ip_id, ip_id2);
+        assert_eq!(stake2.owner, owner2);
+        assert_eq!(stake2.amount, 200i128);
+        assert!(!stake2.slashed);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_batch_stake_commitments_mismatched_lengths_panics() {
+        let env = Env::default();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[13u8; 32]);
+
+        env.mock_all_auths();
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
+
+        let mut ip_ids = Vec::new(&env);
+        ip_ids.push_back(ip_id);
+
+        let mut amounts = Vec::new(&env);
+        amounts.push_back(100i128);
+        amounts.push_back(200i128);
+
+        client.batch_stake_commitments(&ip_ids, &amounts);
+    }
+
+    #[test]
+    fn test_batch_update_reputation_for_multiple_commitments() {
+        let env = Env::default();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner1 = <Address as TestAddress>::generate(&env);
+        let owner2 = <Address as TestAddress>::generate(&env);
+        let commitment1 = BytesN::from_array(&env, &[14u8; 32]);
+        let commitment2 = BytesN::from_array(&env, &[15u8; 32]);
+
+        env.mock_all_auths();
+        let ip_id1 = client.commit_ip(&owner1, &commitment1, &0u32);
+        let ip_id2 = client.commit_ip(&owner2, &commitment2, &0u32);
+
+        let mut ip_ids = Vec::new(&env);
+        ip_ids.push_back(ip_id1);
+        ip_ids.push_back(ip_id2);
+
+        let mut deltas = Vec::new(&env);
+        deltas.push_back(10i64);
+        deltas.push_back(-5i64);
+
+        client.batch_update_reputation(&ip_ids, &deltas);
+
+        let rep1 = client.get_reputation(&owner1);
+        let rep2 = client.get_reputation(&owner2);
+
+        assert_eq!(rep1.score, 10);
+        assert_eq!(rep2.score, -5);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_batch_update_reputation_mismatched_lengths_panics() {
+        let env = Env::default();
+        let contract_id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &contract_id);
+
+        let owner = <Address as TestAddress>::generate(&env);
+        let commitment = BytesN::from_array(&env, &[16u8; 32]);
+
+        env.mock_all_auths();
+        let ip_id = client.commit_ip(&owner, &commitment, &0u32);
+
+        let mut ip_ids = Vec::new(&env);
+        ip_ids.push_back(ip_id);
+
+        let mut deltas = Vec::new(&env);
+        deltas.push_back(10i64);
+        deltas.push_back(20i64);
+
+        client.batch_update_reputation(&ip_ids, &deltas);
     }
 
     #[test]

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -771,6 +771,58 @@ let results = client.batch_verify_commitments(&requests);
 
 ---
 
+## Issue #462 — Batch Staking for IP Commitments
+
+### `batch_stake_commitments`
+
+Stake XLM against multiple IP commitments in a single contract call. Each `ip_ids[i]` is paired with `amounts[i]` and requires the corresponding IP owner to authorize the transaction.
+
+```rust
+pub fn batch_stake_commitments(env: Env, ip_ids: Vec<u64>, amounts: Vec<i128>)
+```
+
+#### Panics
+
+- `BatchSizeMismatch` if `ip_ids.len() != amounts.len()`
+- `AlreadyStaked` if any IP already has an active stake
+- `StakeNotFound` is not returned by this call; it only operates on existing IPs
+
+#### Example
+
+```rust
+let ip_ids = vec![1u64, 2u64];
+let amounts = vec![100i128, 200i128];
+client.batch_stake_commitments(&ip_ids, &amounts);
+```
+
+---
+
+## Issue #463 — Batch Reputation Update for Multiple Commitments
+
+### `batch_update_reputation`
+
+Update reputation scores for multiple IP commitments in one call. Each `ip_ids[i]` is used to resolve the owner, and `score_deltas[i]` is applied to that owner's reputation record.
+
+```rust
+pub fn batch_update_reputation(env: Env, ip_ids: Vec<u64>, score_deltas: Vec<i64>)
+```
+
+#### Panics
+
+- `BatchSizeMismatch` if `ip_ids.len() != score_deltas.len()`
+- `Unauthorized` if the caller is not the configured admin
+- `IpNotFound` if any IP ID does not exist
+
+#### Example
+
+```rust
+let ip_ids = vec![1u64, 2u64];
+let score_deltas = vec![10i64, -5i64];
+client.batch_update_reputation(&ip_ids, &score_deltas);
+```
+
+---
+
 ## Issue #459 — Hierarchical Storage for Commitments
 
 Organises IP commitments in a two-level hierarchy: `owner → category → ip_ids`. This enables O(1) category-scoped lookups without scanning the full owner index.


### PR DESCRIPTION
Implements issue  #462 and #463 with new IP registry contract APIs. Added batch staking, batch reputation updates, batch size mismatch handling, regression tests, and docs.

closes #462 
closes #463