### PR TITLE
feat: add batch swap compression and encryption (#525, #526)

### DIFF
--- a/docs/atomic-swap.md
+++ b/docs/atomic-swap.md
@@ -379,3 +379,71 @@ swap_contract.batch_reveal_keys(
 | `BatchKeysRevealedEvent` | `btch_key` | `batch_reveal_keys` |
 
 Individual `SwapInitiatedEvent` events are still emitted per swap inside `batch_initiate_swap`.
+
+---
+
+## Off-Chain Batch Utilities
+
+The following JavaScript utilities live in `src/batch/` and operate entirely off-chain. They are used to prepare or process batch swap data before submitting to the contract or after reading from it.
+
+---
+
+### #525: Batch Swap Compression
+
+**Module:** `src/batch/batchCompressor.js`
+
+Compresses an array of swap record objects into a compact `Buffer` using deflate (Node built-in `zlib`), and decompresses it back. Useful for reducing payload size when transmitting or storing batches off-chain.
+
+```js
+const { compressBatchSwaps, decompressBatchSwaps } = require("./src/batch/batchCompressor");
+
+const swaps = [
+  { swapId: "s1", state: "PENDING", amount: 1000 },
+  { swapId: "s2", state: "PENDING", amount: 2000 },
+];
+
+const compressed = compressBatchSwaps(swaps);       // Buffer
+const restored   = decompressBatchSwaps(compressed); // original array
+```
+
+**Constraints:**
+- `swaps` must be a non-empty array of objects, max 100 entries
+- `compressed` must be a `Buffer` produced by `compressBatchSwaps`
+- Throws `TypeError` for invalid input types, `RangeError` if batch exceeds the limit
+
+---
+
+### #526: Batch Swap Encryption
+
+**Module:** `src/batch/batchEncryptor.js`
+
+Encrypts a `Buffer` of swap data with AES-256-GCM (Node built-in `crypto`) and decrypts it back. The GCM auth tag ensures tampered ciphertext is rejected automatically.
+
+Wire format: `[ 12-byte IV | 16-byte auth-tag | ciphertext ]`
+
+```js
+const crypto = require("crypto");
+const { encryptBatchSwaps, decryptBatchSwaps } = require("./src/batch/batchEncryptor");
+
+const key  = crypto.randomBytes(32); // 256-bit key — store securely
+const data = Buffer.from(JSON.stringify(swaps));
+
+const encrypted = encryptBatchSwaps(data, key);   // Buffer
+const plaintext = decryptBatchSwaps(encrypted, key); // original Buffer
+```
+
+**Constraints:**
+- `key` must be a 32-byte `Buffer` (AES-256)
+- `data` / `encrypted` must be `Buffer` or `Uint8Array`
+- Throws `Error("Decryption failed: invalid key or tampered data.")` on auth failure
+- Each call to `encryptBatchSwaps` uses a fresh random IV, so identical inputs produce different ciphertexts
+
+**Compose with compression:**
+
+```js
+const compressed = compressBatchSwaps(swaps);
+const encrypted  = encryptBatchSwaps(compressed, key);
+// transmit / store `encrypted` ...
+const decrypted  = decryptBatchSwaps(encrypted, key);
+const restored   = decompressBatchSwaps(decrypted);
+```

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  testEnvironment: "node",
+  testMatch: ["**/src/__tests__/**/*.test.js"],
+};

--- a/src/__tests__/batchCompressor.test.js
+++ b/src/__tests__/batchCompressor.test.js
@@ -1,0 +1,67 @@
+const {
+  compressBatchSwaps,
+  decompressBatchSwaps,
+  MAX_BATCH_SIZE,
+} = require("../batch/batchCompressor");
+
+const swap = (id) => ({ swapId: id, state: "PENDING", amount: 1000 });
+
+describe("compressBatchSwaps — validation", () => {
+  test("throws TypeError on empty array", () => {
+    expect(() => compressBatchSwaps([])).toThrow(TypeError);
+  });
+  test("throws TypeError on non-array", () => {
+    expect(() => compressBatchSwaps(null)).toThrow(TypeError);
+  });
+  test("throws RangeError when batch exceeds MAX_BATCH_SIZE", () => {
+    const big = Array.from({ length: MAX_BATCH_SIZE + 1 }, (_, i) => swap(`s${i}`));
+    expect(() => compressBatchSwaps(big)).toThrow(RangeError);
+  });
+  test("throws TypeError when a swap entry is not an object", () => {
+    expect(() => compressBatchSwaps(["not-an-object"])).toThrow(TypeError);
+  });
+});
+
+describe("decompressBatchSwaps — validation", () => {
+  test("throws TypeError on non-Buffer input", () => {
+    expect(() => decompressBatchSwaps("not-a-buffer")).toThrow(TypeError);
+  });
+  test("throws on corrupted bytes", () => {
+    expect(() => decompressBatchSwaps(Buffer.from("garbage"))).toThrow();
+  });
+});
+
+describe("compressBatchSwaps / decompressBatchSwaps — round-trip", () => {
+  test("single swap round-trips correctly", () => {
+    const swaps = [swap("a1")];
+    expect(decompressBatchSwaps(compressBatchSwaps(swaps))).toEqual(swaps);
+  });
+
+  test("multiple swaps round-trip correctly", () => {
+    const swaps = [swap("b1"), swap("b2"), swap("b3")];
+    expect(decompressBatchSwaps(compressBatchSwaps(swaps))).toEqual(swaps);
+  });
+
+  test("large batch (MAX_BATCH_SIZE) round-trips correctly", () => {
+    const swaps = Array.from({ length: MAX_BATCH_SIZE }, (_, i) => swap(`l${i}`));
+    expect(decompressBatchSwaps(compressBatchSwaps(swaps))).toEqual(swaps);
+  });
+
+  test("compressed output is smaller than raw JSON for large batch", () => {
+    const swaps = Array.from({ length: 50 }, (_, i) => ({
+      swapId: `swap-${i}`,
+      state: "PENDING",
+      amount: 1000 + i,
+      seller: "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      buyer:  "GYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY",
+    }));
+    const compressed = compressBatchSwaps(swaps);
+    const raw = Buffer.from(JSON.stringify(swaps), "utf8");
+    expect(compressed.length).toBeLessThan(raw.length);
+  });
+
+  test("swap with nested fields round-trips correctly", () => {
+    const swaps = [{ swapId: "n1", state: "ACTIVE", amount: 500, meta: { tag: "test" } }];
+    expect(decompressBatchSwaps(compressBatchSwaps(swaps))).toEqual(swaps);
+  });
+});

--- a/src/__tests__/batchEncryptor.test.js
+++ b/src/__tests__/batchEncryptor.test.js
@@ -1,0 +1,84 @@
+const crypto = require("crypto");
+const { encryptBatchSwaps, decryptBatchSwaps } = require("../batch/batchEncryptor");
+
+const key32  = () => crypto.randomBytes(32);
+const plain  = () => Buffer.from(JSON.stringify([{ swapId: "s1", amount: 100 }]));
+
+describe("encryptBatchSwaps — validation", () => {
+  test("throws TypeError when data is not a Buffer", () => {
+    expect(() => encryptBatchSwaps("not-a-buffer", key32())).toThrow(TypeError);
+  });
+  test("throws TypeError when key is not a Buffer", () => {
+    expect(() => encryptBatchSwaps(plain(), "not-a-key")).toThrow(TypeError);
+  });
+  test("throws RangeError when key is wrong length", () => {
+    expect(() => encryptBatchSwaps(plain(), Buffer.alloc(16))).toThrow(RangeError);
+  });
+});
+
+describe("decryptBatchSwaps — validation", () => {
+  test("throws TypeError when encrypted is not a Buffer", () => {
+    expect(() => decryptBatchSwaps("not-a-buffer", key32())).toThrow(TypeError);
+  });
+  test("throws TypeError when key is not a Buffer", () => {
+    expect(() => decryptBatchSwaps(Buffer.alloc(40), "not-a-key")).toThrow(TypeError);
+  });
+  test("throws RangeError when encrypted data is too short", () => {
+    expect(() => decryptBatchSwaps(Buffer.alloc(10), key32())).toThrow(RangeError);
+  });
+});
+
+describe("encryptBatchSwaps / decryptBatchSwaps — round-trip", () => {
+  test("encrypts and decrypts back to original plaintext", () => {
+    const key  = key32();
+    const data = plain();
+    expect(decryptBatchSwaps(encryptBatchSwaps(data, key), key)).toEqual(data);
+  });
+
+  test("empty Buffer round-trips correctly", () => {
+    const key  = key32();
+    const data = Buffer.alloc(0);
+    expect(decryptBatchSwaps(encryptBatchSwaps(data, key), key)).toEqual(data);
+  });
+
+  test("large payload round-trips correctly", () => {
+    const key  = key32();
+    const data = Buffer.from(JSON.stringify(
+      Array.from({ length: 100 }, (_, i) => ({ swapId: `s${i}`, amount: i * 10 }))
+    ));
+    expect(decryptBatchSwaps(encryptBatchSwaps(data, key), key)).toEqual(data);
+  });
+
+  test("each encryption produces a different ciphertext (random IV)", () => {
+    const key  = key32();
+    const data = plain();
+    const c1   = encryptBatchSwaps(data, key);
+    const c2   = encryptBatchSwaps(data, key);
+    expect(c1.equals(c2)).toBe(false);
+  });
+});
+
+describe("decryptBatchSwaps — wrong key / tampered data", () => {
+  test("throws when decrypting with a different key", () => {
+    const data      = plain();
+    const encrypted = encryptBatchSwaps(data, key32());
+    expect(() => decryptBatchSwaps(encrypted, key32())).toThrow();
+  });
+
+  test("throws when ciphertext bytes are tampered", () => {
+    const key       = key32();
+    const encrypted = encryptBatchSwaps(plain(), key);
+    // Flip a byte in the ciphertext portion (after IV + tag)
+    const tampered  = Buffer.from(encrypted);
+    tampered[tampered.length - 1] ^= 0xff;
+    expect(() => decryptBatchSwaps(tampered, key)).toThrow();
+  });
+
+  test("throws when auth-tag bytes are tampered", () => {
+    const key       = key32();
+    const encrypted = encryptBatchSwaps(plain(), key);
+    const tampered  = Buffer.from(encrypted);
+    tampered[12] ^= 0xff; // flip a byte in the 16-byte auth tag
+    expect(() => decryptBatchSwaps(tampered, key)).toThrow();
+  });
+});

--- a/src/batch/batchCompressor.js
+++ b/src/batch/batchCompressor.js
@@ -1,0 +1,58 @@
+/**
+ * Swap Batch Compression (#525)
+ * ─────────────────────────────
+ * Off-chain utility to compress / decompress arrays of swap records using
+ * Node's built-in zlib (deflate/inflate) so no extra dependencies are needed.
+ *
+ * Compression is applied to the JSON-serialised batch before transmission or
+ * storage, reducing payload size for large batches.
+ */
+
+const zlib = require("zlib");
+
+const MAX_BATCH_SIZE = 100;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function validateSwaps(swaps) {
+  if (!Array.isArray(swaps) || swaps.length === 0)
+    throw new TypeError("swaps must be a non-empty array.");
+  if (swaps.length > MAX_BATCH_SIZE)
+    throw new RangeError(`Batch size ${swaps.length} exceeds maximum of ${MAX_BATCH_SIZE}.`);
+  for (let i = 0; i < swaps.length; i++) {
+    if (!swaps[i] || typeof swaps[i] !== "object")
+      throw new TypeError(`Swap at index ${i} must be an object.`);
+  }
+}
+
+// ── Core ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Compress an array of swap records into a Buffer.
+ *
+ * @param {object[]} swaps
+ * @returns {Buffer} deflate-compressed bytes
+ */
+function compressBatchSwaps(swaps) {
+  validateSwaps(swaps);
+  const json = JSON.stringify(swaps);
+  return zlib.deflateSync(Buffer.from(json, "utf8"));
+}
+
+/**
+ * Decompress a Buffer produced by compressBatchSwaps back into swap records.
+ *
+ * @param {Buffer} compressed
+ * @returns {object[]}
+ */
+function decompressBatchSwaps(compressed) {
+  if (!Buffer.isBuffer(compressed) && !(compressed instanceof Uint8Array))
+    throw new TypeError("compressed must be a Buffer.");
+  const json = zlib.inflateSync(compressed).toString("utf8");
+  const swaps = JSON.parse(json);
+  if (!Array.isArray(swaps))
+    throw new Error("Decompressed data is not an array.");
+  return swaps;
+}
+
+module.exports = { compressBatchSwaps, decompressBatchSwaps, MAX_BATCH_SIZE };

--- a/src/batch/batchEncryptor.js
+++ b/src/batch/batchEncryptor.js
@@ -1,0 +1,81 @@
+/**
+ * Swap Batch Encryption (#526)
+ * ────────────────────────────
+ * Off-chain utility to encrypt / decrypt arrays of swap records using
+ * AES-256-GCM via Node's built-in `crypto` module.
+ *
+ * The wire format is:  [ 12-byte IV | 16-byte auth-tag | ciphertext ]
+ * Authentication is built into GCM, so tampered ciphertext is rejected
+ * automatically during decryption.
+ */
+
+const crypto = require("crypto");
+
+const ALGORITHM  = "aes-256-gcm";
+const IV_LENGTH  = 12; // 96-bit IV recommended for GCM
+const TAG_LENGTH = 16; // 128-bit auth tag
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function validateKey(key) {
+  if (!Buffer.isBuffer(key) && !(key instanceof Uint8Array))
+    throw new TypeError("key must be a Buffer or Uint8Array.");
+  if (key.length !== 32)
+    throw new RangeError("key must be exactly 32 bytes (AES-256).");
+}
+
+function validateData(data) {
+  if (!Buffer.isBuffer(data) && !(data instanceof Uint8Array))
+    throw new TypeError("data must be a Buffer or Uint8Array.");
+}
+
+// ── Core ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Encrypt a Buffer with AES-256-GCM.
+ *
+ * @param {Buffer} data  - plaintext bytes
+ * @param {Buffer} key   - 32-byte key
+ * @returns {Buffer}     - IV + auth-tag + ciphertext
+ */
+function encryptBatchSwaps(data, key) {
+  validateData(data);
+  validateKey(key);
+
+  const iv     = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv, { authTagLength: TAG_LENGTH });
+  const ct     = Buffer.concat([cipher.update(data), cipher.final()]);
+  const tag    = cipher.getAuthTag();
+
+  return Buffer.concat([iv, tag, ct]);
+}
+
+/**
+ * Decrypt a Buffer produced by encryptBatchSwaps.
+ * Throws if the key is wrong or the ciphertext has been tampered with.
+ *
+ * @param {Buffer} encrypted - IV + auth-tag + ciphertext
+ * @param {Buffer} key       - 32-byte key
+ * @returns {Buffer}         - plaintext bytes
+ */
+function decryptBatchSwaps(encrypted, key) {
+  validateData(encrypted);
+  validateKey(key);
+
+  if (encrypted.length < IV_LENGTH + TAG_LENGTH)
+    throw new RangeError("encrypted data is too short.");
+
+  const iv      = encrypted.slice(0, IV_LENGTH);
+  const tag     = encrypted.slice(IV_LENGTH, IV_LENGTH + TAG_LENGTH);
+  const ct      = encrypted.slice(IV_LENGTH + TAG_LENGTH);
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv, { authTagLength: TAG_LENGTH });
+  decipher.setAuthTag(tag);
+
+  try {
+    return Buffer.concat([decipher.update(ct), decipher.final()]);
+  } catch {
+    throw new Error("Decryption failed: invalid key or tampered data.");
+  }
+}
+
+module.exports = { encryptBatchSwaps, decryptBatchSwaps };


### PR DESCRIPTION
## Summary

Implements two off-chain batch swap utilities in `src/batch/`, following the existing pattern of `batchCanceller.js`, `batchFeeCalculator.js`, etc.

### #525 — Batch Swap Compression
- `src/batch/batchCompressor.js`: `compressBatchSwaps(swaps) → Buffer` / `decompressBatchSwaps(buf) → object[]`
- Uses Node built-in `zlib` (deflate/inflate) — no new dependencies
- Validates batch size (max 100), input types, and array structure

### #526 — Batch Swap Encryption
- `src/batch/batchEncryptor.js`: `encryptBatchSwaps(data, key) → Buffer` / `decryptBatchSwaps(encrypted, key) → Buffer`
- Uses Node built-in `crypto` (AES-256-GCM) — no new dependencies
- Wire format: `12-byte IV | 16-byte auth-tag | ciphertext`
- GCM auth tag rejects tampered ciphertext automatically

## Tests
- 24 tests total, all passing
- Covers: round-trip, empty input, single item, large batch, wrong key rejection, tampered data rejection, random IV uniqueness

## Docs
- `docs/atomic-swap.md` updated with Off-Chain Batch Utilities section including compose example (compress → encrypt → decrypt → decompress)

Closes #525
Closes #526