### PR TITLE
fix: remove unmaintained derivative dependency (RUSTSEC-2024-0388)

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ cargo-fuzz = true
 ip_registry = { path = "../contracts/ip_registry", features = ["testutils"] }
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1", features = ["derive"] }
-soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+soroban-sdk = { version = "26.0.1", features = ["testutils"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"


### PR DESCRIPTION
## Summary
Resolves security advisory RUSTSEC-2024-0388 by upgrading soroban-sdk.

## Changes
- Upgrade soroban-sdk in fuzz from v22.0.0 to v26.0.1
- Removes transitive dependency on derivative v2.2.0 (unmaintained)
- arkworks v0.5.x (used by soroban-sdk v26.0.1) no longer depends on derivative

## Testing
- Fuzz targets use only standard Soroban SDK APIs (stable across versions)
- No breaking changes to contract or test interfaces

Closes #602 