### PR TITLE
feat: add batch anonymity accessor and batch escrow (#464, #465)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,17 @@ batch_verify_commitments(requests) -> Vec<VerifyResult>  // #458: Verify multipl
 assign_ip_to_category(ip_id, category_hash)       // #459: Assign IP to a hierarchical category
 list_ip_by_category(owner, category_hash) -> Vec<u64>    // #459: List IPs in a category
 list_owner_categories(owner) -> Vec<BytesN<32>>   // #459: List all categories for an owner
+
+// #464: Anonymous Batch Commitments
+batch_commit_ip_anonymous(blinded_owner, commitment_hashes) -> Vec<u64>  // Register commitments without revealing submitter
+get_anonymous_owner(commitment_hash) -> Option<BytesN<32>>               // Retrieve blinded owner for anonymous commitment
+get_blinded_owner_batch(commitment_hashes) -> Vec<Option<BytesN<32>>>   // Batch lookup of blinded owners
+
+// #465: Batch Escrow
+batch_escrow_commitments(depositor, ip_ids, release_to, timeout) -> BytesN<32>  // Escrow multiple IPs for conditional release
+get_batch_escrow(escrow_id) -> Option<EscrowRecord>                              // Retrieve escrow record
+release_batch_escrow(escrow_id)                                                  // Release escrowed IPs to beneficiary
+cancel_batch_escrow(escrow_id)                                                   // Cancel escrow after timeout
 ```
 
 ### Atomic Swap

--- a/contracts/ip_registry/src/lib.rs
+++ b/contracts/ip_registry/src/lib.rs
@@ -73,6 +73,12 @@ pub enum ContractError {
     BatchMetadataTooLarge = 27,
     /// #457: Encrypted data too large.
     EncryptedDataTooLarge = 28,
+    /// #465: Escrow not found.
+    EscrowNotFound = 29,
+    /// #465: Escrow already released or cancelled.
+    EscrowNotActive = 30,
+    /// #465: Timeout not reached for cancellation.
+    EscrowTimeoutNotReached = 31,
 }
 
 // ── TTL ───────────────────────────────────────────────────────────────────────
@@ -139,6 +145,15 @@ pub enum DataKey {
     // Issue #459: Hierarchical storage
     HierarchyNode(Address, BytesN<32>), // maps (owner, category_hash) -> Vec<u64> of IP IDs
     OwnerCategories(Address),           // maps owner -> Vec<BytesN<32>> of category hashes
+    // Issue #454: Threshold signatures
+    ThresholdConfig(u64),
+    ThresholdSignatures(u64),
+    // Issue #455: Batch metadata
+    BatchMetadata(u64),
+    // Issue #457: Encrypted commitment
+    EncryptedCommitment(u64),
+    // Issue #465: Batch escrow — keyed by escrow_id (sha256 of ip_ids + timestamp)
+    BatchEscrow(BytesN<32>),
 }
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -306,6 +321,31 @@ pub struct EncryptedCommitmentRecord {
     pub ip_id: u64,
     pub encrypted_hash: Bytes,    // commitment hash encrypted with owner's key
     pub key_hint: BytesN<32>,     // public key hint (e.g. sha256 of owner's public key)
+    pub timestamp: u64,
+}
+
+// ── Issue #465: Batch Escrow ─────────────────────────────────────────────────
+
+/// Escrow status for batch commitment escrow.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+#[repr(u32)]
+pub enum EscrowStatus {
+    Active = 0,
+    Released = 1,
+    Cancelled = 2,
+}
+
+/// Escrow record for multiple commitments held in trust.
+#[contracttype]
+#[derive(Clone)]
+pub struct EscrowRecord {
+    pub escrow_id: BytesN<32>,
+    pub depositor: Address,
+    pub ip_ids: soroban_sdk::Vec<u64>,
+    pub release_to: Address,
+    pub timeout: u64,
+    pub status: EscrowStatus,
     pub timestamp: u64,
 }
 
@@ -794,6 +834,156 @@ impl IpRegistry {
         env.storage()
             .persistent()
             .get(&DataKey::AnonymousOwner(commitment_hash))
+    }
+
+    /// Retrieve blinded owner identifiers for multiple commitment hashes in a batch.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment
+    /// * `commitment_hashes` - Vector of commitment hashes to look up
+    ///
+    /// # Returns
+    ///
+    /// `Vec<Option<BytesN<32>>>` — For each hash, the blinded owner or `None`.
+    pub fn get_blinded_owner_batch(env: Env, commitment_hashes: Vec<BytesN<32>>) -> Vec<Option<BytesN<32>>> {
+        let mut results = Vec::new(&env);
+        for hash in commitment_hashes.iter() {
+            results.push_back(Self::get_anonymous_owner(env.clone(), hash));
+        }
+        results
+    }
+
+    // ── Issue #465: Batch Escrow ────────────────────────────────────────────
+
+    /// Escrow multiple IP commitments for conditional release.
+    ///
+    /// Creates an escrow record holding multiple IP IDs. The depositor locks
+    /// ownership until either released to the beneficiary or cancelled after timeout.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment
+    /// * `depositor` - Address initiating the escrow (must own all IP IDs)
+    /// * `ip_ids` - Vector of IP IDs to escrow
+    /// * `release_to` - Address that can claim the IPs upon release
+    /// * `timeout` - Ledger timestamp after which depositor can cancel
+    ///
+    /// # Returns
+    ///
+    /// `BytesN<32>` — Unique escrow ID (sha256 of ip_ids + timestamp)
+    pub fn batch_escrow_commitments(
+        env: Env,
+        depositor: Address,
+        ip_ids: Vec<u64>,
+        release_to: Address,
+        timeout: u64,
+    ) -> BytesN<32> {
+        depositor.require_auth();
+
+        for ip_id in ip_ids.iter() {
+            let record = require_ip_exists(&env, ip_id);
+            if record.owner != depositor {
+                panic_with_error!(&env, ContractError::Unauthorized);
+            }
+        }
+
+        let timestamp = env.ledger().timestamp();
+        let mut id_bytes = Bytes::new(&env);
+        for ip_id in ip_ids.iter() {
+            id_bytes.append(&Bytes::from_array(&env, &ip_id.to_be_bytes()));
+        }
+        id_bytes.append(&Bytes::from_array(&env, &timestamp.to_be_bytes()));
+        let escrow_id: BytesN<32> = env.crypto().sha256(&id_bytes).into();
+
+        let escrow = EscrowRecord {
+            escrow_id: escrow_id.clone(),
+            depositor: depositor.clone(),
+            ip_ids: ip_ids.clone(),
+            release_to,
+            timeout,
+            status: EscrowStatus::Active,
+            timestamp,
+        };
+
+        env.storage().persistent().set(&DataKey::BatchEscrow(escrow_id.clone()), &escrow);
+        env.storage().persistent().extend_ttl(&DataKey::BatchEscrow(escrow_id.clone()), LEDGER_BUMP, LEDGER_BUMP);
+
+        env.events().publish((symbol_short!("escrow"), depositor), (escrow_id.clone(), ip_ids.len()));
+
+        escrow_id
+    }
+
+    /// Retrieve an escrow record by ID.
+    ///
+    /// # Returns
+    ///
+    /// `Option<EscrowRecord>` — The escrow record, or `None` if not found.
+    pub fn get_batch_escrow(env: Env, escrow_id: BytesN<32>) -> Option<EscrowRecord> {
+        env.storage().persistent().get(&DataKey::BatchEscrow(escrow_id))
+    }
+
+    /// Release escrowed IPs to the beneficiary.
+    ///
+    /// Transfers ownership of all escrowed IPs to `release_to` address.
+    /// Only the depositor can release before timeout.
+    ///
+    /// # Panics
+    ///
+    /// Panics if escrow not found, not active, or caller unauthorized.
+    pub fn release_batch_escrow(env: Env, escrow_id: BytesN<32>) {
+        let mut escrow: EscrowRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::BatchEscrow(escrow_id.clone()))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::EscrowNotFound));
+
+        if escrow.status != EscrowStatus::Active {
+            panic_with_error!(&env, ContractError::EscrowNotActive);
+        }
+
+        escrow.depositor.require_auth();
+
+        for ip_id in escrow.ip_ids.iter() {
+            Self::transfer_ip(env.clone(), ip_id, escrow.release_to.clone());
+        }
+
+        escrow.status = EscrowStatus::Released;
+        env.storage().persistent().set(&DataKey::BatchEscrow(escrow_id.clone()), &escrow);
+        env.storage().persistent().extend_ttl(&DataKey::BatchEscrow(escrow_id.clone()), LEDGER_BUMP, LEDGER_BUMP);
+
+        env.events().publish((symbol_short!("esc_rel"), escrow.depositor.clone()), escrow_id);
+    }
+
+    /// Cancel escrow and return IPs to depositor.
+    ///
+    /// Only callable by depositor after timeout has passed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if escrow not found, not active, timeout not reached, or caller unauthorized.
+    pub fn cancel_batch_escrow(env: Env, escrow_id: BytesN<32>) {
+        let mut escrow: EscrowRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::BatchEscrow(escrow_id.clone()))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::EscrowNotFound));
+
+        if escrow.status != EscrowStatus::Active {
+            panic_with_error!(&env, ContractError::EscrowNotActive);
+        }
+
+        escrow.depositor.require_auth();
+
+        if env.ledger().timestamp() < escrow.timeout {
+            panic_with_error!(&env, ContractError::EscrowTimeoutNotReached);
+        }
+
+        escrow.status = EscrowStatus::Cancelled;
+        env.storage().persistent().set(&DataKey::BatchEscrow(escrow_id.clone()), &escrow);
+        env.storage().persistent().extend_ttl(&DataKey::BatchEscrow(escrow_id.clone()), LEDGER_BUMP, LEDGER_BUMP);
+
+        env.events().publish((symbol_short!("esc_cnl"), escrow.depositor.clone()), escrow_id);
     }
 
     /// Transfer IP ownership to a new address.

--- a/contracts/ip_registry/src/test.rs
+++ b/contracts/ip_registry/src/test.rs
@@ -67,6 +67,13 @@ mod tests {
         fn batch_update_reputation(env: Env, ip_ids: Vec<u64>, score_deltas: Vec<i64>);
         fn get_reputation(env: Env, owner: Address) -> crate::ReputationRecord;
         fn get_anonymous_owner(env: Env, commitment_hash: BytesN<32>) -> Option<BytesN<32>>;
+        // Issue #464: Batch anonymity accessor
+        fn get_blinded_owner_batch(env: Env, commitment_hashes: Vec<BytesN<32>>) -> Vec<Option<BytesN<32>>>;
+        // Issue #465: Batch escrow
+        fn batch_escrow_commitments(env: Env, depositor: Address, ip_ids: Vec<u64>, release_to: Address, timeout: u64) -> BytesN<32>;
+        fn get_batch_escrow(env: Env, escrow_id: BytesN<32>) -> Option<crate::EscrowRecord>;
+        fn release_batch_escrow(env: Env, escrow_id: BytesN<32>);
+        fn cancel_batch_escrow(env: Env, escrow_id: BytesN<32>);
         // Issue #433
         fn issue_ownership_challenge(env: Env, ip_id: u64, challenger: Address, nonce: BytesN<32>) -> u64;
         fn respond_to_ownership_challenge(env: Env, challenge_id: u64, response_hash: BytesN<32>);
@@ -2452,5 +2459,226 @@ mod expiry_tests {
             false
         });
         assert!(found, "ip_clean event must be emitted");
+    }
+}
+
+// ── #464: get_blinded_owner_batch tests ──────────────────────────────────────
+
+#[cfg(test)]
+mod blinded_owner_batch_tests {
+    use super::tests::{IpRegistry, IpRegistryClient};
+    use soroban_sdk::{contractclient, testutils::Address as _, Address, BytesN, Env, Vec};
+
+    fn setup() -> (Env, IpRegistryClient<'static>) {
+        let env = Env::default();
+        let id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &id);
+        (env, client)
+    }
+
+    #[test]
+    fn test_get_blinded_owner_batch_returns_stored_values() {
+        let (env, client) = setup();
+        let blinded = BytesN::from_array(&env, &[0xABu8; 32]);
+        let h1 = BytesN::from_array(&env, &[0x11u8; 32]);
+        let h2 = BytesN::from_array(&env, &[0x22u8; 32]);
+        client.batch_commit_ip_anonymous(&blinded, &Vec::from_array(&env, [h1.clone(), h2.clone()]));
+
+        let results = client.get_blinded_owner_batch(&Vec::from_array(&env, [h1, h2]));
+        assert_eq!(results.len(), 2);
+        assert_eq!(results.get(0).unwrap(), Some(blinded.clone()));
+        assert_eq!(results.get(1).unwrap(), Some(blinded));
+    }
+
+    #[test]
+    fn test_get_blinded_owner_batch_returns_none_for_non_anonymous() {
+        let (env, client) = setup();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+        let h = BytesN::from_array(&env, &[0x33u8; 32]);
+        client.commit_ip(&owner, &h, &0u32);
+
+        let results = client.get_blinded_owner_batch(&Vec::from_array(&env, [h]));
+        assert_eq!(results.get(0).unwrap(), None);
+    }
+
+    #[test]
+    fn test_get_blinded_owner_batch_empty_input() {
+        let (env, client) = setup();
+        let empty: Vec<BytesN<32>> = Vec::new(&env);
+        let results = client.get_blinded_owner_batch(&empty);
+        assert_eq!(results.len(), 0);
+    }
+
+    #[test]
+    fn test_get_blinded_owner_batch_mixed_results() {
+        let (env, client) = setup();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+        let h_regular = BytesN::from_array(&env, &[0x44u8; 32]);
+        client.commit_ip(&owner, &h_regular, &0u32);
+
+        let blinded = BytesN::from_array(&env, &[0xCCu8; 32]);
+        let h_anon = BytesN::from_array(&env, &[0x55u8; 32]);
+        client.batch_commit_ip_anonymous(&blinded, &Vec::from_array(&env, [h_anon.clone()]));
+
+        let results = client.get_blinded_owner_batch(&Vec::from_array(&env, [h_regular, h_anon]));
+        assert_eq!(results.len(), 2);
+        assert_eq!(results.get(0).unwrap(), None);
+        assert_eq!(results.get(1).unwrap(), Some(blinded));
+    }
+}
+
+// ── #465: Batch Escrow tests ──────────────────────────────────────────────────
+
+#[cfg(test)]
+mod batch_escrow_tests {
+    use super::tests::IpRegistryClient;
+    use crate::EscrowStatus;
+    use soroban_sdk::{testutils::{Address as _, Ledger}, Address, BytesN, Env, Vec};
+
+    fn setup_with_ips(n: u64) -> (Env, IpRegistryClient<'static>, Address, Vec<u64>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &id);
+        let owner = Address::generate(&env);
+        let mut ids = Vec::new(&env);
+        for i in 0..n {
+            let mut hash = [0u8; 32];
+            hash[0] = (i + 1) as u8;
+            let ip_id = client.commit_ip(&owner, &BytesN::from_array(&env, &hash), &0u32);
+            ids.push_back(ip_id);
+        }
+        (env, client, owner, ids)
+    }
+
+    #[test]
+    fn test_batch_escrow_created_and_retrievable() {
+        let (env, client, owner, ip_ids) = setup_with_ips(2);
+        let beneficiary = Address::generate(&env);
+        let timeout = env.ledger().timestamp() + 1000;
+
+        let escrow_id = client.batch_escrow_commitments(&owner, &ip_ids, &beneficiary, &timeout);
+
+        let escrow = client.get_batch_escrow(&escrow_id).expect("escrow should exist");
+        assert_eq!(escrow.status, EscrowStatus::Active);
+        assert_eq!(escrow.depositor, owner);
+        assert_eq!(escrow.release_to, beneficiary);
+        assert_eq!(escrow.ip_ids.len(), 2);
+    }
+
+    #[test]
+    fn test_release_batch_escrow_transfers_ownership() {
+        let (env, client, owner, ip_ids) = setup_with_ips(2);
+        let beneficiary = Address::generate(&env);
+        let timeout = env.ledger().timestamp() + 1000;
+
+        let escrow_id = client.batch_escrow_commitments(&owner, &ip_ids, &beneficiary, &timeout);
+        client.release_batch_escrow(&escrow_id);
+
+        let escrow = client.get_batch_escrow(&escrow_id).unwrap();
+        assert_eq!(escrow.status, EscrowStatus::Released);
+
+        // IPs now owned by beneficiary
+        for ip_id in ip_ids.iter() {
+            let record = client.get_ip(&ip_id);
+            assert_eq!(record.owner, beneficiary);
+        }
+    }
+
+    #[test]
+    fn test_cancel_batch_escrow_after_timeout() {
+        let (env, client, owner, ip_ids) = setup_with_ips(1);
+        let beneficiary = Address::generate(&env);
+        let timeout = env.ledger().timestamp() + 100;
+
+        let escrow_id = client.batch_escrow_commitments(&owner, &ip_ids, &beneficiary, &timeout);
+
+        // Advance past timeout
+        env.ledger().with_mut(|l| l.timestamp = timeout + 1);
+        client.cancel_batch_escrow(&escrow_id);
+
+        let escrow = client.get_batch_escrow(&escrow_id).unwrap();
+        assert_eq!(escrow.status, EscrowStatus::Cancelled);
+
+        // IPs still owned by owner (no transfer on cancel)
+        let record = client.get_ip(&ip_ids.get(0).unwrap());
+        assert_eq!(record.owner, owner);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_cancel_before_timeout_panics() {
+        let (env, client, owner, ip_ids) = setup_with_ips(1);
+        let beneficiary = Address::generate(&env);
+        let timeout = env.ledger().timestamp() + 9999;
+
+        let escrow_id = client.batch_escrow_commitments(&owner, &ip_ids, &beneficiary, &timeout);
+        // Timeout not reached — must panic
+        client.cancel_batch_escrow(&escrow_id);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_release_already_released_panics() {
+        let (env, client, owner, ip_ids) = setup_with_ips(1);
+        let beneficiary = Address::generate(&env);
+        let timeout = env.ledger().timestamp() + 1000;
+
+        let escrow_id = client.batch_escrow_commitments(&owner, &ip_ids, &beneficiary, &timeout);
+        client.release_batch_escrow(&escrow_id);
+        // Second release — must panic
+        client.release_batch_escrow(&escrow_id);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_escrow_non_owner_ip_panics() {
+        let (env, client, _owner, ip_ids) = setup_with_ips(1);
+        let attacker = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        let timeout = env.ledger().timestamp() + 1000;
+
+        // attacker does not own ip_ids — must panic
+        client.batch_escrow_commitments(&attacker, &ip_ids, &beneficiary, &timeout);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_get_batch_escrow_unknown_id_returns_none_not_panic() {
+        // Accessing nonexistent escrow via release should panic
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &id);
+        let fake_id = BytesN::from_array(&env, &[0xFFu8; 32]);
+        client.release_batch_escrow(&fake_id);
+    }
+
+    #[test]
+    fn test_get_batch_escrow_unknown_returns_none() {
+        let env = Env::default();
+        let id = env.register(crate::IpRegistry, ());
+        let client = IpRegistryClient::new(&env, &id);
+        let fake_id = BytesN::from_array(&env, &[0xFFu8; 32]);
+        assert_eq!(client.get_batch_escrow(&fake_id), None);
+    }
+
+    #[test]
+    fn test_batch_escrow_unique_ids_per_call() {
+        let (env, client, owner, ip_ids) = setup_with_ips(2);
+        let beneficiary = Address::generate(&env);
+        let timeout = env.ledger().timestamp() + 1000;
+
+        // Two separate escrow calls on different IPs should produce different IDs
+        let mut ids1_vec = Vec::new(&env);
+        ids1_vec.push_back(ip_ids.get(0).unwrap());
+        let mut ids2_vec = Vec::new(&env);
+        ids2_vec.push_back(ip_ids.get(1).unwrap());
+
+        let eid1 = client.batch_escrow_commitments(&owner, &ids1_vec, &beneficiary, &timeout);
+        let eid2 = client.batch_escrow_commitments(&owner, &ids2_vec, &beneficiary, &timeout);
+        assert_ne!(eid1, eid2);
     }
 }


### PR DESCRIPTION
## Summary

Implements two features for the `ip_registry` Soroban smart contract.

### #464 — Batch Anonymity Accessor

- Adds `get_blinded_owner_batch(commitment_hashes) -> Vec<Option<BytesN<32>>>` for efficient batch lookup of blinded owners stored via `batch_commit_ip_anonymous`

### #465 — Batch Escrow

- **Types**: `EscrowStatus` enum (Active/Released/Cancelled), `EscrowRecord` struct
- **Storage**: `DataKey::BatchEscrow(BytesN<32>)`
- **Error codes**: `EscrowNotFound`, `EscrowNotActive`, `EscrowTimeoutNotReached`
- **Functions**:
  - `batch_escrow_commitments(depositor, ip_ids, release_to, timeout) -> BytesN<32>`
  - `get_batch_escrow(escrow_id) -> Option<EscrowRecord>`
  - `release_batch_escrow(escrow_id)` — transfers IPs to beneficiary
  - `cancel_batch_escrow(escrow_id)` — cancels after timeout

### Tests (13 new)

- Anonymity: batch lookup, empty input, mixed results, non-anonymous returns None
- Escrow: creation, release + ownership transfer, cancel after timeout, early cancel panics, double-release panics, non-owner escrow panics, unknown escrow returns None, unique escrow IDs

### Files Changed

- `contracts/ip_registry/src/lib.rs` — implementation
- `contracts/ip_registry/src/test.rs` — test suite
- `README.md` — API reference updated
closes #464 
closes #465 